### PR TITLE
feat(economy): add safe self-service payout requests

### DIFF
--- a/apps/api/Source/GameGuild.API/Core/Controllers/EconomyWalletController.cs
+++ b/apps/api/Source/GameGuild.API/Core/Controllers/EconomyWalletController.cs
@@ -4,6 +4,8 @@ using GameGuild.CQRS;
 using GameGuild.Economy.Commands;
 using GameGuild.Economy.Contracts;
 using GameGuild.Economy.Funding;
+using GameGuild.Economy.Payouts;
+using GameGuild.Economy.Payouts.Commands;
 using GameGuild.Economy.Payouts.Queries;
 using GameGuild.Economy.Queries;
 using GameGuild.Economy.Risk;
@@ -113,6 +115,92 @@ public sealed class EconomyWalletController(
         var payouts = await sender.Send(new ListMyPayoutOperationsQuery(actorId, take), cancellationToken)
             .ConfigureAwait(false);
         return Ok(payouts);
+    }
+
+    [HttpPost("payout-requests")]
+    [EndpointSummary("Submit my payout request")]
+    [EndpointDescription("Records a withdrawal request only. It does not reserve or transfer value until KYC, risk, provider, and FIFO eligibility checks pass.")]
+    [ProducesResponseType(typeof(EconomyPayoutRequestDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> CreateMyPayoutRequest(
+        [FromBody] CreateMyPayoutRequestRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (!HasSelfServiceContext())
+            return Forbid();
+
+        ArgumentNullException.ThrowIfNull(request);
+        try
+        {
+            var created = await sender.Send(new CreateMyPayoutRequestCommand(request), cancellationToken)
+                .ConfigureAwait(false);
+            return StatusCode(StatusCodes.Status201Created, created);
+        }
+        catch (PayoutRequestWalletUnavailableException exception)
+        {
+            return Conflict(exception.Message);
+        }
+        catch (PayoutRequestInsufficientWithdrawableFundsException exception)
+        {
+            return Conflict(exception.Message);
+        }
+        catch (PayoutRequestReplayConflictException exception)
+        {
+            return Conflict(exception.Message);
+        }
+    }
+
+    [HttpGet("payout-requests")]
+    [EndpointSummary("List my payout requests")]
+    [ProducesResponseType(typeof(IReadOnlyList<EconomyPayoutRequestDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> ListMyPayoutRequests(
+        [FromQuery] int take = 50,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetSelfServiceActorId(out var actorId))
+            return Forbid();
+        if (take is < 1 or > 100)
+            return BadRequest("Take must be between 1 and 100.");
+
+        var requests = await sender.Send(new ListMyPayoutRequestsQuery(actorId, take), cancellationToken)
+            .ConfigureAwait(false);
+        return Ok(requests);
+    }
+
+    [HttpPost("payout-requests/{requestId:guid}/cancel")]
+    [EndpointSummary("Cancel my pending payout request")]
+    [ProducesResponseType(typeof(EconomyPayoutRequestDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CancelMyPayoutRequest(
+        Guid requestId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!HasSelfServiceContext())
+            return Forbid();
+
+        try
+        {
+            var cancelled = await sender.Send(new CancelMyPayoutRequestCommand(requestId), cancellationToken)
+                .ConfigureAwait(false);
+            return Ok(cancelled);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (PayoutRequestStaleCommandException exception)
+        {
+            return Conflict(exception.Message);
+        }
+        catch (PayoutRequestTransitionException exception)
+        {
+            return Conflict(exception.Message);
+        }
     }
 
     [HttpGet("payouts/{operationId:guid}")]

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.Security.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.Security.cs
@@ -2,9 +2,9 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace GameGuild.API.Database.Migrations;
 
-public partial class AddEconomyPayoutRequestPersistence
+internal static class PayoutRequestPersistenceSql
 {
-    private static void InstallPayoutRequestSecurity(MigrationBuilder migrationBuilder)
+    internal static void Install(MigrationBuilder migrationBuilder)
     {
         migrationBuilder.Sql(
             """
@@ -150,7 +150,7 @@ public partial class AddEconomyPayoutRequestPersistence
             """);
     }
 
-    private static void RemovePayoutRequestSecurity(MigrationBuilder migrationBuilder)
+    internal static void Remove(MigrationBuilder migrationBuilder)
     {
         migrationBuilder.Sql(
             """

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.Security.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.Security.cs
@@ -1,0 +1,165 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GameGuild.API.Database.Migrations;
+
+public partial class AddEconomyPayoutRequestPersistence
+{
+    private static void InstallPayoutRequestSecurity(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(
+            """
+            CREATE OR REPLACE FUNCTION economy_private.create_payout_request_v1(
+                p_id uuid, p_idempotency_key text, p_request_hash text, p_payee_id uuid,
+                p_wallet_id uuid, p_amount_units bigint, p_state integer, p_version bigint,
+                p_created_at timestamptz, p_updated_at timestamptz)
+            RETURNS void
+            LANGUAGE plpgsql
+            SECURITY DEFINER
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+            BEGIN
+                IF p_id IS NULL OR p_payee_id IS NULL OR p_wallet_id IS NULL
+                   OR p_amount_units <= 0 OR p_state <> 1 OR p_version <> 1
+                   OR p_created_at IS NULL OR p_updated_at <> p_created_at
+                   OR pg_catalog.length(pg_catalog.btrim(p_idempotency_key)) = 0
+                   OR pg_catalog.length(pg_catalog.btrim(p_request_hash)) <> 64 THEN
+                    RAISE EXCEPTION 'payout request creation violates immutable request rules'
+                        USING ERRCODE = '23514';
+                END IF;
+
+                PERFORM 1
+                FROM public.economy_wallets
+                WHERE "Id" = p_wallet_id AND "OwnerId" = p_payee_id AND "State" = 1;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'payout request wallet does not belong to the requesting payee'
+                        USING ERRCODE = '42501';
+                END IF;
+
+                INSERT INTO public.economy_payout_requests (
+                    "Id", "IdempotencyKey", "RequestHash", "PayeeId", "WalletId", "AmountUnits",
+                    "State", "Version", "CreatedAt", "UpdatedAt")
+                VALUES (
+                    p_id, pg_catalog.btrim(p_idempotency_key), pg_catalog.btrim(p_request_hash),
+                    p_payee_id, p_wallet_id, p_amount_units, p_state, p_version, p_created_at, p_updated_at);
+            EXCEPTION WHEN unique_violation THEN
+                RAISE EXCEPTION 'payout request overlaps an active wallet request or reuses an idempotency key'
+                    USING ERRCODE = '23505';
+            END
+            $function$;
+
+            CREATE OR REPLACE FUNCTION economy_private.transition_payout_request_v1(
+                p_id uuid, p_payee_id uuid, p_expected_version bigint, p_state integer,
+                p_updated_at timestamptz)
+            RETURNS void
+            LANGUAGE plpgsql
+            SECURITY DEFINER
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+            DECLARE
+                current public.economy_payout_requests%ROWTYPE;
+            BEGIN
+                SELECT * INTO current
+                FROM public.economy_payout_requests
+                WHERE "Id" = p_id AND "PayeeId" = p_payee_id
+                FOR UPDATE;
+                IF NOT FOUND THEN
+                    RAISE EXCEPTION 'payout request was not found for the requesting payee'
+                        USING ERRCODE = 'P0002';
+                END IF;
+                IF current."Version" <> p_expected_version OR p_updated_at < current."UpdatedAt" THEN
+                    RAISE EXCEPTION 'payout request version is stale' USING ERRCODE = '40001';
+                END IF;
+                IF current."State" <> 1 OR p_state <> 2 THEN
+                    RAISE EXCEPTION 'payout request transition is invalid' USING ERRCODE = '23514';
+                END IF;
+
+                UPDATE public.economy_payout_requests
+                SET "State" = p_state,
+                    "Version" = current."Version" + 1,
+                    "UpdatedAt" = p_updated_at
+                WHERE "Id" = p_id;
+            END
+            $function$;
+
+            CREATE OR REPLACE FUNCTION economy_private.read_payout_request_by_idempotency_v1(
+                p_payee_id uuid, p_idempotency_key text)
+            RETURNS SETOF public.economy_payout_requests
+            LANGUAGE sql STABLE SECURITY DEFINER
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+                SELECT * FROM public.economy_payout_requests
+                WHERE "PayeeId" = p_payee_id
+                  AND "IdempotencyKey" = pg_catalog.btrim(p_idempotency_key)
+            $function$;
+
+            CREATE OR REPLACE FUNCTION economy_private.read_payout_request_by_id_for_payee_v1(p_id uuid, p_payee_id uuid)
+            RETURNS SETOF public.economy_payout_requests
+            LANGUAGE sql STABLE SECURITY DEFINER
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+                SELECT * FROM public.economy_payout_requests
+                WHERE "Id" = p_id AND "PayeeId" = p_payee_id
+            $function$;
+
+            CREATE OR REPLACE FUNCTION economy_private.read_payout_requests_by_payee_v1(p_payee_id uuid, p_take integer)
+            RETURNS SETOF public.economy_payout_requests
+            LANGUAGE sql STABLE SECURITY DEFINER
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+                SELECT * FROM public.economy_payout_requests
+                WHERE "PayeeId" = p_payee_id
+                ORDER BY "CreatedAt" DESC, "Id" DESC
+                LIMIT GREATEST(1, LEAST(p_take, 100))
+            $function$;
+            """);
+
+        migrationBuilder.Sql(
+            """
+            ALTER FUNCTION economy_private.create_payout_request_v1(
+                uuid,text,text,uuid,uuid,bigint,integer,bigint,timestamptz,timestamptz)
+                OWNER TO gameguild_economy_procedure_owner;
+            ALTER FUNCTION economy_private.transition_payout_request_v1(uuid,uuid,bigint,integer,timestamptz)
+                OWNER TO gameguild_economy_procedure_owner;
+            ALTER FUNCTION economy_private.read_payout_request_by_idempotency_v1(uuid,text)
+                OWNER TO gameguild_economy_procedure_owner;
+            ALTER FUNCTION economy_private.read_payout_request_by_id_for_payee_v1(uuid,uuid)
+                OWNER TO gameguild_economy_procedure_owner;
+            ALTER FUNCTION economy_private.read_payout_requests_by_payee_v1(uuid,integer)
+                OWNER TO gameguild_economy_procedure_owner;
+
+            REVOKE ALL ON TABLE public.economy_payout_requests FROM PUBLIC;
+            REVOKE ALL ON TABLE public.economy_payout_requests FROM gameguild_economy_writer;
+            REVOKE ALL ON TABLE public.economy_payout_requests FROM gameguild_economy_runtime;
+            GRANT SELECT, INSERT, UPDATE ON TABLE public.economy_payout_requests TO gameguild_economy_procedure_owner;
+            GRANT ALL ON TABLE public.economy_payout_requests TO gameguild_economy_migration;
+
+            REVOKE ALL ON FUNCTION economy_private.create_payout_request_v1(
+                uuid,text,text,uuid,uuid,bigint,integer,bigint,timestamptz,timestamptz) FROM PUBLIC;
+            REVOKE ALL ON FUNCTION economy_private.transition_payout_request_v1(uuid,uuid,bigint,integer,timestamptz) FROM PUBLIC;
+            REVOKE ALL ON FUNCTION economy_private.read_payout_request_by_idempotency_v1(uuid,text) FROM PUBLIC;
+            REVOKE ALL ON FUNCTION economy_private.read_payout_request_by_id_for_payee_v1(uuid,uuid) FROM PUBLIC;
+            REVOKE ALL ON FUNCTION economy_private.read_payout_requests_by_payee_v1(uuid,integer) FROM PUBLIC;
+
+            GRANT EXECUTE ON FUNCTION economy_private.create_payout_request_v1(
+                uuid,text,text,uuid,uuid,bigint,integer,bigint,timestamptz,timestamptz),
+                economy_private.transition_payout_request_v1(uuid,uuid,bigint,integer,timestamptz),
+                economy_private.read_payout_request_by_idempotency_v1(uuid,text),
+                economy_private.read_payout_request_by_id_for_payee_v1(uuid,uuid),
+                economy_private.read_payout_requests_by_payee_v1(uuid,integer)
+                TO gameguild_economy_writer;
+            """);
+    }
+
+    private static void RemovePayoutRequestSecurity(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(
+            """
+            DROP FUNCTION IF EXISTS economy_private.create_payout_request_v1(
+                uuid,text,text,uuid,uuid,bigint,integer,bigint,timestamptz,timestamptz);
+            DROP FUNCTION IF EXISTS economy_private.transition_payout_request_v1(uuid,uuid,bigint,integer,timestamptz);
+            DROP FUNCTION IF EXISTS economy_private.read_payout_request_by_idempotency_v1(uuid,text);
+            DROP FUNCTION IF EXISTS economy_private.read_payout_request_by_id_for_payee_v1(uuid,uuid);
+            DROP FUNCTION IF EXISTS economy_private.read_payout_requests_by_payee_v1(uuid,integer);
+            """);
+    }
+}

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.cs
@@ -1,0 +1,71 @@
+using GameGuild.API.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GameGuild.API.Database.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260811120000_AddEconomyPayoutRequestPersistence")]
+public partial class AddEconomyPayoutRequestPersistence : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "economy_payout_requests",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                IdempotencyKey = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                RequestHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                PayeeId = table.Column<Guid>(type: "uuid", nullable: false),
+                WalletId = table.Column<Guid>(type: "uuid", nullable: false),
+                AmountUnits = table.Column<long>(type: "bigint", nullable: false),
+                State = table.Column<int>(type: "integer", nullable: false),
+                Version = table.Column<long>(type: "bigint", nullable: false),
+                CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_economy_payout_requests", x => x.Id);
+                table.CheckConstraint("ck_economy_payout_requests_amount_positive", "\"AmountUnits\" > 0");
+                table.CheckConstraint("ck_economy_payout_requests_state", "\"State\" BETWEEN 1 AND 4");
+                table.CheckConstraint("ck_economy_payout_requests_version_positive", "\"Version\" > 0");
+                table.CheckConstraint("ck_economy_payout_requests_timestamps", "\"UpdatedAt\" >= \"CreatedAt\"");
+                table.ForeignKey(
+                    name: "FK_economy_payout_requests_economy_wallets_WalletId",
+                    column: x => x.WalletId,
+                    principalTable: "economy_wallets",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Restrict);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "ux_economy_payout_requests_payee_idempotency",
+            table: "economy_payout_requests",
+            columns: new[] { "PayeeId", "IdempotencyKey" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "ux_economy_payout_requests_active_wallet",
+            table: "economy_payout_requests",
+            column: "WalletId",
+            unique: true,
+            filter: "\"State\" IN (1, 3)");
+
+        migrationBuilder.CreateIndex(
+            name: "ix_economy_payout_requests_payee_created",
+            table: "economy_payout_requests",
+            columns: new[] { "PayeeId", "CreatedAt" });
+
+        InstallPayoutRequestSecurity(migrationBuilder);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        RemovePayoutRequestSecurity(migrationBuilder);
+        migrationBuilder.DropTable(name: "economy_payout_requests");
+    }
+}

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811120000_AddEconomyPayoutRequestPersistence.cs
@@ -60,12 +60,12 @@ public partial class AddEconomyPayoutRequestPersistence : Migration
             table: "economy_payout_requests",
             columns: new[] { "PayeeId", "CreatedAt" });
 
-        InstallPayoutRequestSecurity(migrationBuilder);
+        PayoutRequestPersistenceSql.Install(migrationBuilder);
     }
 
     protected override void Down(MigrationBuilder migrationBuilder)
     {
-        RemovePayoutRequestSecurity(migrationBuilder);
+        PayoutRequestPersistenceSql.Remove(migrationBuilder);
         migrationBuilder.DropTable(name: "economy_payout_requests");
     }
 }

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/Commands/SelfServicePayoutRequestCommands.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/Commands/SelfServicePayoutRequestCommands.cs
@@ -1,0 +1,110 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentValidation;
+using GameGuild.CQRS;
+using GameGuild.Economy.Contracts;
+using GameGuild.Economy.Payouts.Queries;
+using GameGuild.Economy.Queries;
+using GameGuild.Identity.Context.Actors;
+
+namespace GameGuild.Economy.Payouts.Commands;
+
+public sealed record CreateMyPayoutRequestRequest(long HardCoinUnits, string IdempotencyKey);
+
+public sealed record CreateMyPayoutRequestCommand(CreateMyPayoutRequestRequest Request)
+    : ICommand<EconomyPayoutRequestDto>;
+
+public sealed record CancelMyPayoutRequestCommand(Guid RequestId)
+    : ICommand<EconomyPayoutRequestDto>;
+
+public sealed class CreateMyPayoutRequestCommandValidator : AbstractValidator<CreateMyPayoutRequestCommand>
+{
+    public CreateMyPayoutRequestCommandValidator()
+    {
+        RuleFor(command => command.Request).NotNull();
+        When(command => command.Request is not null, () =>
+        {
+            RuleFor(command => command.Request.HardCoinUnits).GreaterThan(0);
+            RuleFor(command => command.Request.IdempotencyKey).NotEmpty().MaximumLength(128);
+        });
+    }
+}
+
+public sealed class CreateMyPayoutRequestCommandHandler(
+    ISender sender,
+    IActorContextAccessor actorContextAccessor,
+    IPayoutRequestStore requests)
+    : ICommandHandler<CreateMyPayoutRequestCommand, EconomyPayoutRequestDto>
+{
+    public async Task<EconomyPayoutRequestDto> Handle(
+        CreateMyPayoutRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(command.Request);
+        var actor = RequireActor(actorContextAccessor);
+        var wallet = await sender.Send(new GetMyEconomyWalletQuery(), cancellationToken).ConfigureAwait(false)
+            ?? throw new PayoutRequestWalletUnavailableException(
+                "Create an Economy wallet before requesting a payout.");
+        if (wallet.State != WalletLifecycleState.Active)
+            throw new PayoutRequestWalletUnavailableException(
+                "An active Economy wallet is required before requesting a payout.");
+        var requestHash = ComputeRequestHash(actor, wallet.WalletId, command.Request.HardCoinUnits);
+        var replay = requests.FindReplay(actor, command.Request.IdempotencyKey.Trim(), requestHash);
+        if (replay is not null)
+            return EconomyPayoutRequestDto.From(replay);
+        if (command.Request.HardCoinUnits > wallet.WithdrawableHard)
+            throw new PayoutRequestInsufficientWithdrawableFundsException(
+                "The payout request exceeds HardCoin value that is confirmed and eligible for withdrawal.");
+
+        var now = DateTimeOffset.UtcNow;
+        var request = new PayoutRequest(
+            Guid.NewGuid(),
+            new IdempotencyKey(command.Request.IdempotencyKey.Trim()),
+            requestHash,
+            actor,
+            new WalletId(wallet.WalletId),
+            new CoinAmount(CurrencyCode.HardCoin, command.Request.HardCoinUnits),
+            PayoutRequestState.Submitted,
+            1,
+            now,
+            now);
+        requests.Add(request);
+        return EconomyPayoutRequestDto.From(request);
+    }
+
+    private static Guid RequireActor(IActorContextAccessor accessor)
+    {
+        var actor = accessor.ActorContext;
+        return actor.IsAuthenticated && actor.SubjectIdAsGuid is { } actorId && actor.TenantId.HasValue
+            ? actorId
+            : throw new UnauthorizedAccessException("An authenticated tenant actor is required for payout requests.");
+    }
+
+    private static string ComputeRequestHash(Guid actorId, Guid walletId, long amountUnits)
+    {
+        var payload = $"{actorId:N}|{walletId:N}|{amountUnits}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload))).ToLowerInvariant();
+    }
+}
+
+public sealed class CancelMyPayoutRequestCommandHandler(
+    IActorContextAccessor actorContextAccessor,
+    IPayoutRequestStore requests)
+    : ICommandHandler<CancelMyPayoutRequestCommand, EconomyPayoutRequestDto>
+{
+    public Task<EconomyPayoutRequestDto> Handle(
+        CancelMyPayoutRequestCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        cancellationToken.ThrowIfCancellationRequested();
+        var actor = actorContextAccessor.ActorContext;
+        if (!actor.IsAuthenticated || actor.SubjectIdAsGuid is not { } actorId || !actor.TenantId.HasValue)
+            throw new UnauthorizedAccessException("An authenticated tenant actor is required for payout requests.");
+
+        var current = requests.GetForPayee(command.RequestId, actorId);
+        var cancelled = current.Cancel(DateTimeOffset.UtcNow);
+        return Task.FromResult(EconomyPayoutRequestDto.From(requests.Update(cancelled, current.Version)));
+    }
+}

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/Commands/SelfServicePayoutRequestCommands.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/Commands/SelfServicePayoutRequestCommands.cs
@@ -47,15 +47,21 @@ public sealed class CreateMyPayoutRequestCommandHandler(
             ?? throw new PayoutRequestWalletUnavailableException(
                 "Create an Economy wallet before requesting a payout.");
         if (wallet.State != WalletLifecycleState.Active)
+        {
             throw new PayoutRequestWalletUnavailableException(
                 "An active Economy wallet is required before requesting a payout.");
+        }
         var requestHash = ComputeRequestHash(actor, wallet.WalletId, command.Request.HardCoinUnits);
         var replay = requests.FindReplay(actor, command.Request.IdempotencyKey.Trim(), requestHash);
         if (replay is not null)
+        {
             return EconomyPayoutRequestDto.From(replay);
+        }
         if (command.Request.HardCoinUnits > wallet.WithdrawableHard)
+        {
             throw new PayoutRequestInsufficientWithdrawableFundsException(
                 "The payout request exceeds HardCoin value that is confirmed and eligible for withdrawal.");
+        }
 
         var now = DateTimeOffset.UtcNow;
         var request = new PayoutRequest(
@@ -101,7 +107,9 @@ public sealed class CancelMyPayoutRequestCommandHandler(
         cancellationToken.ThrowIfCancellationRequested();
         var actor = actorContextAccessor.ActorContext;
         if (!actor.IsAuthenticated || actor.SubjectIdAsGuid is not { } actorId || !actor.TenantId.HasValue)
+        {
             throw new UnauthorizedAccessException("An authenticated tenant actor is required for payout requests.");
+        }
 
         var current = requests.GetForPayee(command.RequestId, actorId);
         var cancelled = current.Cancel(DateTimeOffset.UtcNow);

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutRequestContracts.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutRequestContracts.cs
@@ -1,0 +1,63 @@
+using GameGuild.Economy.Contracts;
+
+namespace GameGuild.Economy.Payouts;
+
+/// <summary>
+/// A user-submitted intent to withdraw earned value. It is deliberately separate from a
+/// <see cref="PayoutOperation"/>: no funds are reserved or sent until the request has passed
+/// the later KYC, risk, provider, and FIFO reservation steps.
+/// </summary>
+public enum PayoutRequestState
+{
+    Submitted = 1,
+    Cancelled = 2,
+    Approved = 3,
+    Rejected = 4
+}
+
+public sealed record PayoutRequest(
+    Guid Id,
+    IdempotencyKey IdempotencyKey,
+    string RequestHash,
+    Guid PayeeId,
+    WalletId WalletId,
+    CoinAmount Amount,
+    PayoutRequestState State,
+    long Version,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt)
+{
+    public PayoutRequest Cancel(DateTimeOffset occurredAt)
+    {
+        if (State != PayoutRequestState.Submitted)
+            throw new PayoutRequestTransitionException("Only a submitted payout request can be cancelled.");
+        if (occurredAt < UpdatedAt)
+            throw new ArgumentOutOfRangeException(nameof(occurredAt), "Payout request timestamps cannot move backwards.");
+
+        return this with
+        {
+            State = PayoutRequestState.Cancelled,
+            Version = checked(Version + 1),
+            UpdatedAt = occurredAt
+        };
+    }
+}
+
+public interface IPayoutRequestStore
+{
+    PayoutRequest? FindReplay(Guid payeeId, string idempotencyKey, string requestHash);
+
+    void Add(PayoutRequest request);
+
+    PayoutRequest GetForPayee(Guid requestId, Guid payeeId);
+
+    IReadOnlyList<PayoutRequest> ListForPayee(Guid payeeId, int take);
+
+    PayoutRequest Update(PayoutRequest request, long expectedVersion);
+}
+
+public sealed class PayoutRequestReplayConflictException(string message) : InvalidOperationException(message);
+public sealed class PayoutRequestStaleCommandException(string message) : InvalidOperationException(message);
+public sealed class PayoutRequestWalletUnavailableException(string message) : InvalidOperationException(message);
+public sealed class PayoutRequestInsufficientWithdrawableFundsException(string message) : InvalidOperationException(message);
+public sealed class PayoutRequestTransitionException(string message) : InvalidOperationException(message);

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutRequestContracts.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutRequestContracts.cs
@@ -30,9 +30,13 @@ public sealed record PayoutRequest(
     public PayoutRequest Cancel(DateTimeOffset occurredAt)
     {
         if (State != PayoutRequestState.Submitted)
+        {
             throw new PayoutRequestTransitionException("Only a submitted payout request can be cancelled.");
+        }
         if (occurredAt < UpdatedAt)
+        {
             throw new ArgumentOutOfRangeException(nameof(occurredAt), "Payout request timestamps cannot move backwards.");
+        }
 
         return this with
         {

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutsModule.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PayoutsModule.cs
@@ -11,6 +11,7 @@ public sealed class PayoutsModule : ModuleBase
     public override IServiceCollection ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
         services.AddScoped<IPayoutOperationStore, PostgreSqlPayoutOperationStore>();
+        services.AddScoped<IPayoutRequestStore, PostgreSqlPayoutRequestStore>();
 
         // Read-only payout status is safe without a payout provider. Write workflows remain
         // opt-in because they require provider evidence verification and execution gates.

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
@@ -1,0 +1,152 @@
+using GameGuild.Economy.Contracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace GameGuild.Economy.Payouts;
+
+/// <summary>
+/// Uses database-owned procedures so application roles cannot insert or mutate payout requests
+/// outside their constrained state transitions.
+/// </summary>
+public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
+{
+    private readonly DbContext _db;
+
+    public PostgreSqlPayoutRequestStore(IApplicationDbContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _db = context as DbContext
+            ?? throw new InvalidOperationException(
+                "PostgreSQL payout request persistence requires the application's relational DbContext.");
+    }
+
+    public PayoutRequest? FindReplay(Guid payeeId, string idempotencyKey, string requestHash)
+    {
+        if (payeeId == Guid.Empty)
+            throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+        ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestHash);
+
+        var row = Read($"""
+            SELECT * FROM economy_private.read_payout_request_by_idempotency_v1({payeeId}, {idempotencyKey.Trim()})
+            """).SingleOrDefault();
+        if (row is null)
+            return null;
+        if (!string.Equals(row.RequestHash, requestHash, StringComparison.Ordinal))
+            throw new PayoutRequestReplayConflictException(
+                "Payout request idempotency key was reused with different inputs.");
+
+        return ToContract(row);
+    }
+
+    public void Add(PayoutRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Execute($"""
+            SELECT economy_private.create_payout_request_v1(
+                {request.Id},
+                {request.IdempotencyKey.Value},
+                {request.RequestHash},
+                {request.PayeeId},
+                {request.WalletId.Value},
+                {request.Amount.Units},
+                {(int)request.State},
+                {request.Version},
+                {request.CreatedAt},
+                {request.UpdatedAt});
+            """);
+    }
+
+    public PayoutRequest GetForPayee(Guid requestId, Guid payeeId)
+    {
+        if (requestId == Guid.Empty)
+            throw new ArgumentException("Payout request ID is required.", nameof(requestId));
+        if (payeeId == Guid.Empty)
+            throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+
+        var row = Read($"""
+            SELECT * FROM economy_private.read_payout_request_by_id_for_payee_v1({requestId}, {payeeId})
+            """).SingleOrDefault();
+        return row is null
+            ? throw new KeyNotFoundException($"Payout request {requestId:N} was not found.")
+            : ToContract(row);
+    }
+
+    public IReadOnlyList<PayoutRequest> ListForPayee(Guid payeeId, int take)
+    {
+        if (payeeId == Guid.Empty)
+            throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+        if (take is < 1 or > 100)
+            throw new ArgumentOutOfRangeException(nameof(take), "Take must be between 1 and 100.");
+
+        return Read($"""
+            SELECT * FROM economy_private.read_payout_requests_by_payee_v1({payeeId}, {take})
+            """)
+            .OrderByDescending(row => row.CreatedAt)
+            .ThenByDescending(row => row.Id)
+            .Select(ToContract)
+            .ToArray();
+    }
+
+    public PayoutRequest Update(PayoutRequest request, long expectedVersion)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (expectedVersion <= 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedVersion));
+
+        Execute($"""
+            SELECT economy_private.transition_payout_request_v1(
+                {request.Id},
+                {request.PayeeId},
+                {expectedVersion},
+                {(int)request.State},
+                {request.UpdatedAt});
+            """);
+        return request;
+    }
+
+    private IQueryable<PayoutRequestRow> Read(FormattableString sql) =>
+        _db.Database.SqlQuery<PayoutRequestRow>(sql).AsNoTracking();
+
+    private void Execute(FormattableString sql)
+    {
+        try
+        {
+            _db.Database.ExecuteSqlInterpolated(sql);
+        }
+        catch (Exception exception) when (exception.Message.Contains("payout request", StringComparison.OrdinalIgnoreCase))
+        {
+            throw Translate(exception);
+        }
+    }
+
+    private static Exception Translate(Exception exception) =>
+        exception.Message.Contains("idempotency", StringComparison.OrdinalIgnoreCase)
+            ? new PayoutRequestReplayConflictException(exception.Message)
+            : new PayoutRequestStaleCommandException(exception.Message);
+
+    private static PayoutRequest ToContract(PayoutRequestRow row) => new(
+        row.Id,
+        new IdempotencyKey(row.IdempotencyKey),
+        row.RequestHash,
+        row.PayeeId,
+        new WalletId(row.WalletId),
+        new CoinAmount(CurrencyCode.HardCoin, row.AmountUnits),
+        row.State,
+        row.Version,
+        row.CreatedAt,
+        row.UpdatedAt);
+}
+
+public sealed class PayoutRequestRow
+{
+    public Guid Id { get; set; }
+    public string IdempotencyKey { get; set; } = string.Empty;
+    public string RequestHash { get; set; } = string.Empty;
+    public Guid PayeeId { get; set; }
+    public Guid WalletId { get; set; }
+    public long AmountUnits { get; set; }
+    public PayoutRequestState State { get; set; }
+    public long Version { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
@@ -127,7 +127,7 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
         return request;
     }
 
-    private IQueryable<PayoutRequestRow> Read(string sql, params object?[] parameters) =>
+    private IQueryable<PayoutRequestRow> Read(string sql, params object[] parameters) =>
         _db.Database.SqlQueryRaw<PayoutRequestRow>(sql, parameters).AsNoTracking();
 
     private void Execute(FormattableString sql)

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/PostgreSqlPayoutRequestStore.cs
@@ -22,18 +22,27 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
     public PayoutRequest? FindReplay(Guid payeeId, string idempotencyKey, string requestHash)
     {
         if (payeeId == Guid.Empty)
+        {
             throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(idempotencyKey);
         ArgumentException.ThrowIfNullOrWhiteSpace(requestHash);
 
-        var row = Read($"""
-            SELECT * FROM economy_private.read_payout_request_by_idempotency_v1({payeeId}, {idempotencyKey.Trim()})
-            """).SingleOrDefault();
+        var row = Read(
+            "SELECT * FROM economy_private.read_payout_request_by_idempotency_v1({0}, {1})",
+            payeeId,
+            idempotencyKey.Trim()).SingleOrDefault();
         if (row is null)
+        {
             return null;
+        }
+
         if (!string.Equals(row.RequestHash, requestHash, StringComparison.Ordinal))
+        {
             throw new PayoutRequestReplayConflictException(
                 "Payout request idempotency key was reused with different inputs.");
+        }
 
         return ToContract(row);
     }
@@ -59,13 +68,19 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
     public PayoutRequest GetForPayee(Guid requestId, Guid payeeId)
     {
         if (requestId == Guid.Empty)
+        {
             throw new ArgumentException("Payout request ID is required.", nameof(requestId));
-        if (payeeId == Guid.Empty)
-            throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+        }
 
-        var row = Read($"""
-            SELECT * FROM economy_private.read_payout_request_by_id_for_payee_v1({requestId}, {payeeId})
-            """).SingleOrDefault();
+        if (payeeId == Guid.Empty)
+        {
+            throw new ArgumentException("Payee ID is required.", nameof(payeeId));
+        }
+
+        var row = Read(
+            "SELECT * FROM economy_private.read_payout_request_by_id_for_payee_v1({0}, {1})",
+            requestId,
+            payeeId).SingleOrDefault();
         return row is null
             ? throw new KeyNotFoundException($"Payout request {requestId:N} was not found.")
             : ToContract(row);
@@ -74,13 +89,19 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
     public IReadOnlyList<PayoutRequest> ListForPayee(Guid payeeId, int take)
     {
         if (payeeId == Guid.Empty)
+        {
             throw new ArgumentException("Payee ID is required.", nameof(payeeId));
-        if (take is < 1 or > 100)
-            throw new ArgumentOutOfRangeException(nameof(take), "Take must be between 1 and 100.");
+        }
 
-        return Read($"""
-            SELECT * FROM economy_private.read_payout_requests_by_payee_v1({payeeId}, {take})
-            """)
+        if (take is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(take), "Take must be between 1 and 100.");
+        }
+
+        return Read(
+                "SELECT * FROM economy_private.read_payout_requests_by_payee_v1({0}, {1})",
+                payeeId,
+                take)
             .OrderByDescending(row => row.CreatedAt)
             .ThenByDescending(row => row.Id)
             .Select(ToContract)
@@ -91,7 +112,9 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
     {
         ArgumentNullException.ThrowIfNull(request);
         if (expectedVersion <= 0)
+        {
             throw new ArgumentOutOfRangeException(nameof(expectedVersion));
+        }
 
         Execute($"""
             SELECT economy_private.transition_payout_request_v1(
@@ -104,8 +127,8 @@ public sealed class PostgreSqlPayoutRequestStore : IPayoutRequestStore
         return request;
     }
 
-    private IQueryable<PayoutRequestRow> Read(FormattableString sql) =>
-        _db.Database.SqlQuery<PayoutRequestRow>(sql).AsNoTracking();
+    private IQueryable<PayoutRequestRow> Read(string sql, params object?[] parameters) =>
+        _db.Database.SqlQueryRaw<PayoutRequestRow>(sql, parameters).AsNoTracking();
 
     private void Execute(FormattableString sql)
     {

--- a/apps/api/Source/Modules/GameGuild.Economy.Payouts/Queries/SelfServicePayoutQueries.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy.Payouts/Queries/SelfServicePayoutQueries.cs
@@ -9,11 +9,29 @@ public sealed record EconomyPayoutOperationDto(
     DateTimeOffset CreatedAt,
     DateTimeOffset UpdatedAt);
 
+public sealed record EconomyPayoutRequestDto(
+    Guid Id,
+    long HardCoinUnits,
+    PayoutRequestState State,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt)
+{
+    public static EconomyPayoutRequestDto From(PayoutRequest request) => new(
+        request.Id,
+        request.Amount.Units,
+        request.State,
+        request.CreatedAt,
+        request.UpdatedAt);
+}
+
 public sealed record ListMyPayoutOperationsQuery(Guid PayeeId, int Take)
     : IQuery<IReadOnlyList<EconomyPayoutOperationDto>>;
 
 public sealed record GetMyPayoutOperationQuery(Guid PayeeId, Guid OperationId)
     : IQuery<EconomyPayoutOperationDto?>;
+
+public sealed record ListMyPayoutRequestsQuery(Guid PayeeId, int Take)
+    : IQuery<IReadOnlyList<EconomyPayoutRequestDto>>;
 
 public sealed class ListMyPayoutOperationsQueryHandler(IPayoutOperationStore operations)
     : IQueryHandler<ListMyPayoutOperationsQuery, IReadOnlyList<EconomyPayoutOperationDto>>
@@ -67,5 +85,23 @@ public sealed class GetMyPayoutOperationQueryHandler(IPayoutOperationStore opera
         {
             return Task.FromResult<EconomyPayoutOperationDto?>(null);
         }
+    }
+}
+
+public sealed class ListMyPayoutRequestsQueryHandler(IPayoutRequestStore requests)
+    : IQueryHandler<ListMyPayoutRequestsQuery, IReadOnlyList<EconomyPayoutRequestDto>>
+{
+    public Task<IReadOnlyList<EconomyPayoutRequestDto>> Handle(
+        ListMyPayoutRequestsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IReadOnlyList<EconomyPayoutRequestDto> result = requests
+            .ListForPayee(request.PayeeId, request.Take)
+            .Select(EconomyPayoutRequestDto.From)
+            .ToArray();
+        return Task.FromResult(result);
     }
 }

--- a/apps/api/tests/GameGuild.API.UnitTests/Controllers/EconomyWalletControllerPayoutRequestTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Controllers/EconomyWalletControllerPayoutRequestTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using GameGuild.API.Controllers;
+using GameGuild.API.Setup;
+using GameGuild.CQRS;
+using GameGuild.Economy.Payouts;
+using GameGuild.Economy.Payouts.Commands;
+using GameGuild.Economy.Payouts.Queries;
+using GameGuild.Identity.Context.Actors;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace GameGuild.API.UnitTests.Controllers;
+
+public sealed class EconomyWalletControllerPayoutRequestTests
+{
+    [Fact]
+    public async Task CreateReturnsCreatedForTheAuthenticatedActor()
+    {
+        var sender = new Mock<ISender>();
+        var request = new CreateMyPayoutRequestRequest(250, "request-1");
+        var response = new EconomyPayoutRequestDto(
+            Guid.NewGuid(), 250, PayoutRequestState.Submitted, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        sender.Setup(service => service.Send(
+                It.Is<CreateMyPayoutRequestCommand>(command => command.Request == request),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.CreateMyPayoutRequest(request, CancellationToken.None);
+
+        var created = result.Should().BeOfType<ObjectResult>().Subject;
+        created.StatusCode.Should().Be(StatusCodes.Status201Created);
+        created.Value.Should().Be(response);
+    }
+
+    [Fact]
+    public async Task CreateForbidsAnUnauthenticatedActor()
+    {
+        var sender = new Mock<ISender>(MockBehavior.Strict);
+        var controller = CreateController(sender.Object, isAuthenticated: false);
+
+        var result = await controller.CreateMyPayoutRequest(
+            new CreateMyPayoutRequestRequest(250, "request-1"), CancellationToken.None);
+
+        result.Should().BeOfType<ForbidResult>();
+        sender.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CreateReturnsConflictWhenTheActorHasNoWallet()
+    {
+        var sender = new Mock<ISender>();
+        sender.Setup(service => service.Send(
+                It.IsAny<CreateMyPayoutRequestCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PayoutRequestWalletUnavailableException("Create an Economy wallet before requesting a payout."));
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.CreateMyPayoutRequest(
+            new CreateMyPayoutRequestRequest(250, "request-1"), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateReturnsConflictForAnUnsafePayoutRequest()
+    {
+        var sender = new Mock<ISender>();
+        sender.Setup(service => service.Send(
+                It.IsAny<CreateMyPayoutRequestCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PayoutRequestInsufficientWithdrawableFundsException(
+                "The payout request exceeds HardCoin value that is confirmed and eligible for withdrawal."));
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.CreateMyPayoutRequest(
+            new CreateMyPayoutRequestRequest(250, "request-1"), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task CancelReturnsNotFoundForARequestThatDoesNotBelongToTheActor()
+    {
+        var sender = new Mock<ISender>();
+        sender.Setup(service => service.Send(
+                It.IsAny<CancelMyPayoutRequestCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException());
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.CancelMyPayoutRequest(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task CancelReturnsConflictAfterTheRequestHasBeenReviewed()
+    {
+        var sender = new Mock<ISender>();
+        sender.Setup(service => service.Send(
+                It.IsAny<CancelMyPayoutRequestCommand>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new PayoutRequestTransitionException("Only a submitted payout request can be cancelled."));
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.CancelMyPayoutRequest(Guid.NewGuid(), CancellationToken.None);
+
+        result.Should().BeOfType<ConflictObjectResult>();
+    }
+
+    [Fact]
+    public async Task ListRejectsAnInvalidPageSize()
+    {
+        var sender = new Mock<ISender>(MockBehavior.Strict);
+        var controller = CreateController(sender.Object);
+
+        var result = await controller.ListMyPayoutRequests(101, CancellationToken.None);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+        sender.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ListForwardsTheAuthenticatedActorAndPageSize()
+    {
+        var actorId = Guid.NewGuid();
+        var sender = new Mock<ISender>();
+        sender.Setup(service => service.Send(
+                It.Is<ListMyPayoutRequestsQuery>(query => query.PayeeId == actorId && query.Take == 10),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<EconomyPayoutRequestDto>());
+        var controller = CreateController(sender.Object, actorId);
+
+        var result = await controller.ListMyPayoutRequests(10, CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+    }
+
+    private static EconomyWalletController CreateController(
+        ISender sender,
+        Guid? actorId = null,
+        bool isAuthenticated = true)
+    {
+        var actor = new Mock<IActorContextAccessor>();
+        actor.SetupGet(accessor => accessor.ActorContext).Returns(new ActorContext
+        {
+            ActorKind = ActorKind.User,
+            SubjectId = (actorId ?? Guid.NewGuid()).ToString(),
+            TenantId = Guid.NewGuid(),
+            Roles = new HashSet<string>(),
+            Permissions = new HashSet<string>(),
+            TypedAttributes = ActorAttributes.Empty,
+            IsAuthenticated = isAuthenticated
+        });
+        return new EconomyWalletController(
+            sender,
+            actor.Object,
+            Mock.Of<IEconomyProviderCapabilityReadiness>());
+    }
+}

--- a/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
@@ -167,15 +167,27 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
 
     private static async Task ExecuteAsWriterAsync(NpgsqlConnection connection, FormattableString sql)
     {
-        await ExecuteLiteralAsync(connection, "SET ROLE gameguild_economy_writer;");
+        await SetWriterRoleAsync(connection);
         try
         {
             await ExecuteAsync(connection, sql);
         }
         finally
         {
-            await ExecuteLiteralAsync(connection, "RESET ROLE;");
+            await ResetRoleAsync(connection);
         }
+    }
+
+    private static async Task SetWriterRoleAsync(NpgsqlConnection connection)
+    {
+        await using var command = new NpgsqlCommand("SET ROLE gameguild_economy_writer;", connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task ResetRoleAsync(NpgsqlConnection connection)
+    {
+        await using var command = new NpgsqlCommand("RESET ROLE;", connection);
+        await command.ExecuteNonQueryAsync();
     }
 
     private static async Task ExecuteAsync(NpgsqlConnection connection, FormattableString sql)
@@ -191,11 +203,6 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
         return value is null or DBNull ? default! : (T)value;
     }
 
-    private static async Task ExecuteLiteralAsync(NpgsqlConnection connection, string sql)
-    {
-        await using var command = new NpgsqlCommand(sql, connection);
-        await command.ExecuteNonQueryAsync();
-    }
 
     private static NpgsqlCommand CreateCommand(NpgsqlConnection connection, FormattableString sql)
     {

--- a/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
@@ -1,0 +1,203 @@
+using FluentAssertions;
+using GameGuild.API.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace GameGuild.API.UnitTests.Database;
+
+[Collection(PostgreSqlTestCollection.Name)]
+public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 11, 12, 0, 0, TimeSpan.Zero);
+
+    [DockerFact]
+    public async Task WriterPersistsAnOwnedRequestAndOnlyAllowsThePayeeToCancelIt()
+    {
+        await using var container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("economy_payout_requests")
+            .WithUsername("test")
+            .WithPassword("test")
+            .WithCleanUp(true)
+            .Build();
+        await container.StartAsync();
+
+        await using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(container.GetConnectionString())
+                .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options);
+        await context.Database.MigrateAsync();
+
+        await using var connection = new NpgsqlConnection(container.GetConnectionString());
+        await connection.OpenAsync();
+        var payeeId = Guid.NewGuid();
+        var walletId = Guid.NewGuid();
+        var requestId = Guid.NewGuid();
+        await SeedWalletAsync(connection, payeeId, walletId);
+
+        var directInsert = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+            connection,
+            "gameguild_economy_writer",
+            $"INSERT INTO public.economy_payout_requests (\"Id\") VALUES ('{requestId}');"));
+        directInsert.SqlState.Should().Be(PostgresErrorCodes.InsufficientPrivilege);
+
+        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+            SELECT economy_private.create_payout_request_v1(
+                '{requestId}', 'request-1', '{new string('a', 64)}', '{payeeId}', '{walletId}', 250, 1, 1,
+                '{Now:O}', '{Now:O}');
+            """);
+
+        (await ScalarAsync<long>(connection, $"""
+            SELECT "AmountUnits"
+            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            """)).Should().Be(250);
+
+        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+            SELECT economy_private.transition_payout_request_v1(
+                '{requestId}', '{payeeId}', 1, 2, '{Now.AddMinutes(1):O}');
+            """);
+
+        (await ScalarAsync<int>(connection, $"""
+            SELECT "State"
+            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            """)).Should().Be(2);
+        (await ScalarAsync<long>(connection, $"""
+            SELECT "Version"
+            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            """)).Should().Be(2);
+
+        var foreignCancellation = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+            connection,
+            "gameguild_economy_writer",
+            $"SELECT economy_private.transition_payout_request_v1('{requestId}', '{Guid.NewGuid()}', 2, 2, '{Now.AddMinutes(2):O}');"));
+        foreignCancellation.SqlState.Should().Be("P0002");
+    }
+
+    [DockerFact]
+    public async Task WriterRejectsARequestForAnotherPayeesWallet()
+    {
+        await using var container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("economy_payout_request_ownership")
+            .WithUsername("test")
+            .WithPassword("test")
+            .WithCleanUp(true)
+            .Build();
+        await container.StartAsync();
+
+        await using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(container.GetConnectionString())
+                .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options);
+        await context.Database.MigrateAsync();
+
+        await using var connection = new NpgsqlConnection(container.GetConnectionString());
+        await connection.OpenAsync();
+        var ownerId = Guid.NewGuid();
+        var walletId = Guid.NewGuid();
+        await SeedWalletAsync(connection, ownerId, walletId);
+
+        var foreignRequest = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+            connection,
+            "gameguild_economy_writer",
+            $"""
+            SELECT economy_private.create_payout_request_v1(
+                '{Guid.NewGuid()}', 'request-foreign', '{new string('b', 64)}', '{Guid.NewGuid()}', '{walletId}', 250, 1, 1,
+                '{Now:O}', '{Now:O}');
+            """));
+
+        foreignRequest.SqlState.Should().Be(PostgresErrorCodes.InsufficientPrivilege);
+        foreignRequest.MessageText.Should().Contain("does not belong");
+    }
+
+    [DockerFact]
+    public async Task WriterScopesIdempotencyKeysToThePayee()
+    {
+        await using var container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("economy_payout_request_idempotency")
+            .WithUsername("test")
+            .WithPassword("test")
+            .WithCleanUp(true)
+            .Build();
+        await container.StartAsync();
+
+        await using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(container.GetConnectionString())
+                .ConfigureWarnings(warnings => warnings.Ignore(RelationalEventId.PendingModelChangesWarning))
+                .Options);
+        await context.Database.MigrateAsync();
+
+        await using var connection = new NpgsqlConnection(container.GetConnectionString());
+        await connection.OpenAsync();
+        var firstPayee = Guid.NewGuid();
+        var firstWallet = Guid.NewGuid();
+        var secondPayee = Guid.NewGuid();
+        var secondWallet = Guid.NewGuid();
+        await SeedWalletAsync(connection, firstPayee, firstWallet);
+        await SeedWalletAsync(connection, secondPayee, secondWallet);
+
+        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+            SELECT economy_private.create_payout_request_v1(
+                '{Guid.NewGuid()}', 'same-key', '{new string('a', 64)}', '{firstPayee}', '{firstWallet}', 250, 1, 1,
+                '{Now:O}', '{Now:O}');
+            SELECT economy_private.create_payout_request_v1(
+                '{Guid.NewGuid()}', 'same-key', '{new string('b', 64)}', '{secondPayee}', '{secondWallet}', 250, 1, 1,
+                '{Now:O}', '{Now:O}');
+            """);
+
+        (await ScalarAsync<long>(connection, $"""
+            SELECT COUNT(*)
+            FROM economy_private.read_payout_request_by_idempotency_v1('{firstPayee}', 'same-key');
+            """)).Should().Be(1);
+        (await ScalarAsync<long>(connection, $"""
+            SELECT COUNT(*)
+            FROM economy_private.read_payout_request_by_idempotency_v1('{secondPayee}', 'same-key');
+            """)).Should().Be(1);
+    }
+
+    private static Task SeedWalletAsync(NpgsqlConnection connection, Guid ownerId, Guid walletId) => ExecuteAsync(connection, $"""
+        INSERT INTO public.economy_wallets ("Id", "OwnerId", "TenantId", "State", "CreatedAt")
+        VALUES ('{walletId}', '{ownerId}', '{Guid.NewGuid()}', 1, '{Now:O}');
+        """);
+
+    private static async Task ExecuteAsRoleAsync(NpgsqlConnection connection, string role, string sql)
+    {
+        await ExecuteAsync(connection, $"SET ROLE {role};");
+        try
+        {
+            await ExecuteAsync(connection, sql);
+        }
+        finally
+        {
+            await ExecuteAsync(connection, "RESET ROLE;");
+        }
+    }
+
+    private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<T> ScalarAsync<T>(NpgsqlConnection connection, string sql)
+    {
+        await using var command = new NpgsqlCommand(sql, connection);
+        var value = await command.ExecuteScalarAsync();
+        return value is null or DBNull ? default! : (T)value;
+    }
+
+    private sealed class DockerFactAttribute : FactAttribute
+    {
+        public DockerFactAttribute()
+        {
+            if (string.Equals(Environment.GetEnvironmentVariable("SKIP_DOCKER_TESTS"), "1", StringComparison.Ordinal))
+                Skip = "Docker tests disabled by SKIP_DOCKER_TESTS=1.";
+        }
+    }
+}

--- a/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyPayoutRequestPostgreSqlMigrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using GameGuild.API.Database;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,7 @@ namespace GameGuild.API.UnitTests.Database;
 public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
 {
     private static readonly DateTimeOffset Now = new(2026, 8, 11, 12, 0, 0, TimeSpan.Zero);
+    private static readonly Regex SqlFormatItem = new(@"\{(?<index>\d+)(?:,[^}:]+)?(?::[^}]*)?\}", RegexOptions.CultureInvariant);
 
     [DockerFact]
     public async Task WriterPersistsAnOwnedRequestAndOnlyAllowsThePayeeToCancelIt()
@@ -38,41 +40,39 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
         var requestId = Guid.NewGuid();
         await SeedWalletAsync(connection, payeeId, walletId);
 
-        var directInsert = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+        var directInsert = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsWriterAsync(
             connection,
-            "gameguild_economy_writer",
-            $"INSERT INTO public.economy_payout_requests (\"Id\") VALUES ('{requestId}');"));
+            $"""INSERT INTO public.economy_payout_requests ("Id") VALUES ({requestId});"""));
         directInsert.SqlState.Should().Be(PostgresErrorCodes.InsufficientPrivilege);
 
-        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+        await ExecuteAsWriterAsync(connection, $"""
             SELECT economy_private.create_payout_request_v1(
-                '{requestId}', 'request-1', '{new string('a', 64)}', '{payeeId}', '{walletId}', 250, 1, 1,
-                '{Now:O}', '{Now:O}');
+                {requestId}, {"request-1"}, {new string('a', 64)}, {payeeId}, {walletId}, {250}, {1}, {1},
+                {Now}, {Now});
             """);
 
         (await ScalarAsync<long>(connection, $"""
             SELECT "AmountUnits"
-            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            FROM economy_private.read_payout_request_by_id_for_payee_v1({requestId}, {payeeId});
             """)).Should().Be(250);
 
-        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+        await ExecuteAsWriterAsync(connection, $"""
             SELECT economy_private.transition_payout_request_v1(
-                '{requestId}', '{payeeId}', 1, 2, '{Now.AddMinutes(1):O}');
+                {requestId}, {payeeId}, {1}, {2}, {Now.AddMinutes(1)});
             """);
 
         (await ScalarAsync<int>(connection, $"""
             SELECT "State"
-            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            FROM economy_private.read_payout_request_by_id_for_payee_v1({requestId}, {payeeId});
             """)).Should().Be(2);
         (await ScalarAsync<long>(connection, $"""
             SELECT "Version"
-            FROM economy_private.read_payout_request_by_id_for_payee_v1('{requestId}', '{payeeId}');
+            FROM economy_private.read_payout_request_by_id_for_payee_v1({requestId}, {payeeId});
             """)).Should().Be(2);
 
-        var foreignCancellation = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+        var foreignCancellation = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsWriterAsync(
             connection,
-            "gameguild_economy_writer",
-            $"SELECT economy_private.transition_payout_request_v1('{requestId}', '{Guid.NewGuid()}', 2, 2, '{Now.AddMinutes(2):O}');"));
+            $"""SELECT economy_private.transition_payout_request_v1({requestId}, {Guid.NewGuid()}, {2}, {2}, {Now.AddMinutes(2)});"""));
         foreignCancellation.SqlState.Should().Be("P0002");
     }
 
@@ -101,13 +101,12 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
         var walletId = Guid.NewGuid();
         await SeedWalletAsync(connection, ownerId, walletId);
 
-        var foreignRequest = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsRoleAsync(
+        var foreignRequest = await Assert.ThrowsAsync<PostgresException>(() => ExecuteAsWriterAsync(
             connection,
-            "gameguild_economy_writer",
             $"""
             SELECT economy_private.create_payout_request_v1(
-                '{Guid.NewGuid()}', 'request-foreign', '{new string('b', 64)}', '{Guid.NewGuid()}', '{walletId}', 250, 1, 1,
-                '{Now:O}', '{Now:O}');
+                {Guid.NewGuid()}, {"request-foreign"}, {new string('b', 64)}, {Guid.NewGuid()}, {walletId}, {250}, {1}, {1},
+                {Now}, {Now});
             """));
 
         foreignRequest.SqlState.Should().Be(PostgresErrorCodes.InsufficientPrivilege);
@@ -142,54 +141,76 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
         await SeedWalletAsync(connection, firstPayee, firstWallet);
         await SeedWalletAsync(connection, secondPayee, secondWallet);
 
-        await ExecuteAsRoleAsync(connection, "gameguild_economy_writer", $"""
+        await ExecuteAsWriterAsync(connection, $"""
             SELECT economy_private.create_payout_request_v1(
-                '{Guid.NewGuid()}', 'same-key', '{new string('a', 64)}', '{firstPayee}', '{firstWallet}', 250, 1, 1,
-                '{Now:O}', '{Now:O}');
+                {Guid.NewGuid()}, {"same-key"}, {new string('a', 64)}, {firstPayee}, {firstWallet}, {250}, {1}, {1},
+                {Now}, {Now});
             SELECT economy_private.create_payout_request_v1(
-                '{Guid.NewGuid()}', 'same-key', '{new string('b', 64)}', '{secondPayee}', '{secondWallet}', 250, 1, 1,
-                '{Now:O}', '{Now:O}');
+                {Guid.NewGuid()}, {"same-key"}, {new string('b', 64)}, {secondPayee}, {secondWallet}, {250}, {1}, {1},
+                {Now}, {Now});
             """);
 
         (await ScalarAsync<long>(connection, $"""
             SELECT COUNT(*)
-            FROM economy_private.read_payout_request_by_idempotency_v1('{firstPayee}', 'same-key');
+            FROM economy_private.read_payout_request_by_idempotency_v1({firstPayee}, {"same-key"});
             """)).Should().Be(1);
         (await ScalarAsync<long>(connection, $"""
             SELECT COUNT(*)
-            FROM economy_private.read_payout_request_by_idempotency_v1('{secondPayee}', 'same-key');
+            FROM economy_private.read_payout_request_by_idempotency_v1({secondPayee}, {"same-key"});
             """)).Should().Be(1);
     }
 
     private static Task SeedWalletAsync(NpgsqlConnection connection, Guid ownerId, Guid walletId) => ExecuteAsync(connection, $"""
         INSERT INTO public.economy_wallets ("Id", "OwnerId", "TenantId", "State", "CreatedAt")
-        VALUES ('{walletId}', '{ownerId}', '{Guid.NewGuid()}', 1, '{Now:O}');
+        VALUES ({walletId}, {ownerId}, {Guid.NewGuid()}, {1}, {Now});
         """);
 
-    private static async Task ExecuteAsRoleAsync(NpgsqlConnection connection, string role, string sql)
+    private static async Task ExecuteAsWriterAsync(NpgsqlConnection connection, FormattableString sql)
     {
-        await ExecuteAsync(connection, $"SET ROLE {role};");
+        await ExecuteLiteralAsync(connection, "SET ROLE gameguild_economy_writer;");
         try
         {
             await ExecuteAsync(connection, sql);
         }
         finally
         {
-            await ExecuteAsync(connection, "RESET ROLE;");
+            await ExecuteLiteralAsync(connection, "RESET ROLE;");
         }
     }
 
-    private static async Task ExecuteAsync(NpgsqlConnection connection, string sql)
+    private static async Task ExecuteAsync(NpgsqlConnection connection, FormattableString sql)
+    {
+        await using var command = CreateCommand(connection, sql);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<T> ScalarAsync<T>(NpgsqlConnection connection, FormattableString sql)
+    {
+        await using var command = CreateCommand(connection, sql);
+        var value = await command.ExecuteScalarAsync();
+        return value is null or DBNull ? default! : (T)value;
+    }
+
+    private static async Task ExecuteLiteralAsync(NpgsqlConnection connection, string sql)
     {
         await using var command = new NpgsqlCommand(sql, connection);
         await command.ExecuteNonQueryAsync();
     }
 
-    private static async Task<T> ScalarAsync<T>(NpgsqlConnection connection, string sql)
+    private static NpgsqlCommand CreateCommand(NpgsqlConnection connection, FormattableString sql)
     {
-        await using var command = new NpgsqlCommand(sql, connection);
-        var value = await command.ExecuteScalarAsync();
-        return value is null or DBNull ? default! : (T)value;
+        var command = new NpgsqlCommand
+        {
+            Connection = connection,
+            CommandText = SqlFormatItem.Replace(sql.Format, static match => $"@p{match.Groups["index"].Value}")
+        };
+        var arguments = sql.GetArguments();
+        for (var index = 0; index < arguments.Length; index++)
+        {
+            command.Parameters.AddWithValue($"p{index}", arguments[index] ?? DBNull.Value);
+        }
+
+        return command;
     }
 
     private sealed class DockerFactAttribute : FactAttribute
@@ -197,7 +218,9 @@ public sealed class EconomyPayoutRequestPostgreSqlMigrationTests
         public DockerFactAttribute()
         {
             if (string.Equals(Environment.GetEnvironmentVariable("SKIP_DOCKER_TESTS"), "1", StringComparison.Ordinal))
+            {
                 Skip = "Docker tests disabled by SKIP_DOCKER_TESTS=1.";
+            }
         }
     }
 }

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PayoutsModuleTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PayoutsModuleTests.cs
@@ -21,6 +21,10 @@ public sealed class PayoutsModuleTests
             descriptor.ServiceType == typeof(IPayoutOperationStore) &&
             descriptor.ImplementationType == typeof(PostgreSqlPayoutOperationStore) &&
             descriptor.Lifetime == ServiceLifetime.Scoped);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IPayoutRequestStore) &&
+            descriptor.ImplementationType == typeof(PostgreSqlPayoutRequestStore) &&
+            descriptor.Lifetime == ServiceLifetime.Scoped);
         services.Should().NotContain(descriptor =>
             descriptor.ServiceType == typeof(IDurablePayoutReservationWorkflow));
         services.Should().NotContain(descriptor =>

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PostgreSqlPayoutRequestStoreTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PostgreSqlPayoutRequestStoreTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using GameGuild;
+using GameGuild.API.Database;
+using GameGuild.Economy.Contracts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Testcontainers.PostgreSql;
+
+namespace GameGuild.Economy.Payouts.UnitTests;
+
+public sealed class PostgreSqlPayoutRequestStoreTests
+{
+    private static readonly DateTimeOffset Time = new(2026, 8, 11, 18, 0, 0, TimeSpan.Zero);
+
+    [DockerFact]
+    public async Task Store_PersistsReadsReplaysAndCancelsAnOwnedRequest()
+    {
+        await using var container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("economy_payout_request_store")
+            .WithUsername("test")
+            .WithPassword("test")
+            .WithCleanUp(true)
+            .Build();
+        await container.StartAsync();
+
+        await using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(container.GetConnectionString())
+                .Options);
+        await context.Database.MigrateAsync();
+
+        var payeeId = Guid.NewGuid();
+        var walletId = Guid.NewGuid();
+        await context.Database.ExecuteSqlInterpolatedAsync($"""
+            INSERT INTO public.economy_wallets ("Id", "OwnerId", "TenantId", "State", "CreatedAt")
+            VALUES ({walletId}, {payeeId}, {Guid.NewGuid()}, 1, {Time});
+            """);
+
+        var store = new PostgreSqlPayoutRequestStore(context);
+        var request = Request(payeeId, walletId);
+
+        store.Add(request);
+        store.GetForPayee(request.Id, payeeId).Should().BeEquivalentTo(request);
+        store.ListForPayee(payeeId, 10).Should().ContainSingle().Which.Should().BeEquivalentTo(request);
+        store.FindReplay(payeeId, request.IdempotencyKey.Value, request.RequestHash)
+            .Should().BeEquivalentTo(request);
+        store.FindReplay(payeeId, "missing", request.RequestHash).Should().BeNull();
+
+        FluentActions.Invoking(() => store.FindReplay(payeeId, request.IdempotencyKey.Value, "changed"))
+            .Should().Throw<PayoutRequestReplayConflictException>();
+        FluentActions.Invoking(() => store.Add(request with { Id = Guid.NewGuid() }))
+            .Should().Throw<PayoutRequestReplayConflictException>();
+        FluentActions.Invoking(() => store.GetForPayee(Guid.NewGuid(), payeeId))
+            .Should().Throw<KeyNotFoundException>();
+
+        var cancelled = request.Cancel(Time.AddMinutes(1));
+        store.Update(cancelled, request.Version).Should().BeSameAs(cancelled);
+        store.GetForPayee(request.Id, payeeId).Should().BeEquivalentTo(cancelled);
+        FluentActions.Invoking(() => store.Update(cancelled, request.Version))
+            .Should().Throw<PayoutRequestStaleCommandException>();
+    }
+
+    [Fact]
+    public void Store_RejectsInvalidConstructionAndArguments()
+    {
+        FluentActions.Invoking(() => new PostgreSqlPayoutRequestStore(null!))
+            .Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => new PostgreSqlPayoutRequestStore(new NonRelationalContext()))
+            .Should().Throw<InvalidOperationException>();
+
+        using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase($"payout-request-store-validation-{Guid.NewGuid():N}")
+                .Options);
+        var store = new PostgreSqlPayoutRequestStore(context);
+        var request = Request(Guid.NewGuid(), Guid.NewGuid());
+
+        FluentActions.Invoking(() => store.FindReplay(Guid.Empty, "request", "hash"))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.FindReplay(Guid.NewGuid(), "", "hash"))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.FindReplay(Guid.NewGuid(), "request", ""))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.Add(null!)).Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => store.GetForPayee(Guid.Empty, Guid.NewGuid()))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.GetForPayee(Guid.NewGuid(), Guid.Empty))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.ListForPayee(Guid.Empty, 10))
+            .Should().Throw<ArgumentException>();
+        FluentActions.Invoking(() => store.ListForPayee(Guid.NewGuid(), 0))
+            .Should().Throw<ArgumentOutOfRangeException>();
+        FluentActions.Invoking(() => store.ListForPayee(Guid.NewGuid(), 101))
+            .Should().Throw<ArgumentOutOfRangeException>();
+        FluentActions.Invoking(() => store.Update(null!, 1)).Should().Throw<ArgumentNullException>();
+        FluentActions.Invoking(() => store.Update(request, 0)).Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static PayoutRequest Request(Guid payeeId, Guid walletId) => new(
+        Guid.NewGuid(),
+        new IdempotencyKey($"request-{Guid.NewGuid():N}"),
+        new string('a', 64),
+        payeeId,
+        new WalletId(walletId),
+        new CoinAmount(CurrencyCode.HardCoin, 250),
+        PayoutRequestState.Submitted,
+        1,
+        Time,
+        Time);
+
+    private sealed class NonRelationalContext : IApplicationDbContext
+    {
+        public DbSet<T> Set<T>() where T : class => throw new NotSupportedException();
+
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class DockerFactAttribute : FactAttribute
+    {
+        public DockerFactAttribute()
+        {
+            if (string.Equals(Environment.GetEnvironmentVariable("SKIP_DOCKER_TESTS"), "1", StringComparison.Ordinal))
+                Skip = "Docker tests disabled by SKIP_DOCKER_TESTS=1.";
+        }
+    }
+}

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PostgreSqlPayoutRequestStoreTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/PostgreSqlPayoutRequestStoreTests.cs
@@ -113,11 +113,17 @@ public sealed class PostgreSqlPayoutRequestStoreTests
     {
         public DbSet<T> Set<T>() where T : class => throw new NotSupportedException();
 
-        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+        public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException();
+        }
 
-        public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default) =>
+        public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             throw new NotSupportedException();
+        }
     }
 
     private sealed class DockerFactAttribute : FactAttribute
@@ -125,7 +131,9 @@ public sealed class PostgreSqlPayoutRequestStoreTests
         public DockerFactAttribute()
         {
             if (string.Equals(Environment.GetEnvironmentVariable("SKIP_DOCKER_TESTS"), "1", StringComparison.Ordinal))
+            {
                 Skip = "Docker tests disabled by SKIP_DOCKER_TESTS=1.";
+            }
         }
     }
 }

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
@@ -97,6 +97,51 @@ public sealed class SelfServicePayoutRequestTests
     }
 
     [Fact]
+    public async Task CreateRequiresAnExistingWallet()
+    {
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(null),
+            AuthenticatedAccessor(Guid.NewGuid()),
+            new InMemoryPayoutRequestStore());
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1")),
+                CancellationToken.None))
+            .Should().ThrowAsync<PayoutRequestWalletUnavailableException>();
+    }
+
+    [Theory]
+    [InlineData(false, "00000000-0000-0000-0000-000000000001", true)]
+    [InlineData(true, "not-a-guid", true)]
+    [InlineData(true, "00000000-0000-0000-0000-000000000001", false)]
+    public async Task CreateRequiresEachPartOfAnAuthenticatedTenantActor(
+        bool authenticated,
+        string subjectId,
+        bool hasTenant)
+    {
+        var accessor = new ActorContextAccessor();
+        accessor.SetActorContext(new ActorContext
+        {
+            ActorKind = ActorKind.User,
+            SubjectId = subjectId,
+            TenantId = hasTenant ? Guid.NewGuid() : null,
+            Roles = new HashSet<string>(),
+            Permissions = new HashSet<string>(),
+            TypedAttributes = ActorAttributes.Empty,
+            IsAuthenticated = authenticated
+        });
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid())),
+            accessor,
+            new InMemoryPayoutRequestStore());
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1")),
+                CancellationToken.None))
+            .Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
     public async Task CancelOnlyChangesTheAuthenticatedPayeesSubmittedRequest()
     {
         var actorId = Guid.NewGuid();
@@ -237,11 +282,11 @@ public sealed class SelfServicePayoutRequestTests
             timestamp);
     }
 
-    private sealed class WalletSender(EconomyWalletSummaryDto wallet) : ISender
+    private sealed class WalletSender(EconomyWalletSummaryDto? wallet) : ISender
     {
         public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default) =>
             request is GetMyEconomyWalletQuery
-                ? Task.FromResult((TResponse)(object)wallet)
+                ? Task.FromResult((TResponse)(object?)wallet!)
                 : throw new InvalidOperationException($"Unexpected request {request.GetType().Name}.");
 
         public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
@@ -1,0 +1,271 @@
+using FluentAssertions;
+using GameGuild.CQRS;
+using GameGuild.Economy.Contracts;
+using GameGuild.Economy.Payouts.Commands;
+using GameGuild.Economy.Payouts.Queries;
+using GameGuild.Economy.Queries;
+using GameGuild.Identity.Context.Actors;
+
+namespace GameGuild.Economy.Payouts.UnitTests;
+
+public sealed class SelfServicePayoutRequestTests
+{
+    [Fact]
+    public async Task CreateBindsTheRequestToTheAuthenticatedActorsWalletAndReplaysIdempotently()
+    {
+        var actorId = Guid.Parse("b1000000-0000-0000-0000-000000000001");
+        var walletId = Guid.Parse("b1000000-0000-0000-0000-000000000002");
+        var accessor = AuthenticatedAccessor(actorId);
+        var store = new InMemoryPayoutRequestStore();
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(walletId)), accessor, store);
+        var command = new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1"));
+
+        var created = await handler.Handle(command, CancellationToken.None);
+        var replay = await handler.Handle(command, CancellationToken.None);
+
+        created.HardCoinUnits.Should().Be(250);
+        created.State.Should().Be(PayoutRequestState.Submitted);
+        replay.Id.Should().Be(created.Id);
+        store.Items.Should().ContainSingle(item => item.PayeeId == actorId && item.WalletId.Value == walletId);
+    }
+
+    [Fact]
+    public async Task CreateRejectsAReusedIdempotencyKeyWithDifferentValue()
+    {
+        var actorId = Guid.NewGuid();
+        var accessor = AuthenticatedAccessor(actorId);
+        var store = new InMemoryPayoutRequestStore();
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid())), accessor, store);
+
+        await handler.Handle(
+            new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1")),
+            CancellationToken.None);
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(251, "request-1")),
+                CancellationToken.None))
+            .Should().ThrowAsync<PayoutRequestReplayConflictException>();
+    }
+
+    [Fact]
+    public async Task CreateAllowsDifferentPayeesToUseTheSameIdempotencyKey()
+    {
+        var store = new InMemoryPayoutRequestStore();
+        var firstActorId = Guid.NewGuid();
+        var secondActorId = Guid.NewGuid();
+        var first = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid())), AuthenticatedAccessor(firstActorId), store);
+        var command = new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1"));
+
+        var firstRequest = await first.Handle(command, CancellationToken.None);
+        var second = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid())), AuthenticatedAccessor(secondActorId), store);
+        var secondRequest = await second.Handle(command, CancellationToken.None);
+
+        secondRequest.Id.Should().NotBe(firstRequest.Id);
+        store.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task CreateRejectsValueAboveTheConfirmedWithdrawableBalance()
+    {
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid(), withdrawableHard: 249)),
+            AuthenticatedAccessor(Guid.NewGuid()),
+            new InMemoryPayoutRequestStore());
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1")),
+                CancellationToken.None))
+            .Should().ThrowAsync<PayoutRequestInsufficientWithdrawableFundsException>();
+    }
+
+    [Fact]
+    public async Task CreateRejectsAnInactiveWallet()
+    {
+        var handler = new CreateMyPayoutRequestCommandHandler(
+            new WalletSender(CreateWallet(Guid.NewGuid(), state: WalletLifecycleState.Frozen)),
+            AuthenticatedAccessor(Guid.NewGuid()),
+            new InMemoryPayoutRequestStore());
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CreateMyPayoutRequestCommand(new CreateMyPayoutRequestRequest(250, "request-1")),
+                CancellationToken.None))
+            .Should().ThrowAsync<PayoutRequestWalletUnavailableException>();
+    }
+
+    [Fact]
+    public async Task CancelOnlyChangesTheAuthenticatedPayeesSubmittedRequest()
+    {
+        var actorId = Guid.NewGuid();
+        var store = new InMemoryPayoutRequestStore();
+        var request = CreateRequest(actorId, PayoutRequestState.Submitted);
+        store.Add(request);
+        var handler = new CancelMyPayoutRequestCommandHandler(AuthenticatedAccessor(actorId), store);
+
+        var cancelled = await handler.Handle(new CancelMyPayoutRequestCommand(request.Id), CancellationToken.None);
+
+        cancelled.State.Should().Be(PayoutRequestState.Cancelled);
+        cancelled.UpdatedAt.Should().BeOnOrAfter(request.UpdatedAt);
+        store.GetForPayee(request.Id, actorId).Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CancelRejectsARequestThatIsNoLongerSubmitted()
+    {
+        var actorId = Guid.NewGuid();
+        var store = new InMemoryPayoutRequestStore();
+        var request = CreateRequest(actorId, PayoutRequestState.Approved);
+        store.Add(request);
+        var handler = new CancelMyPayoutRequestCommandHandler(AuthenticatedAccessor(actorId), store);
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CancelMyPayoutRequestCommand(request.Id), CancellationToken.None))
+            .Should().ThrowAsync<PayoutRequestTransitionException>();
+    }
+
+    [Fact]
+    public async Task ListReturnsOnlyThePayeesRequests()
+    {
+        var payeeId = Guid.NewGuid();
+        var store = new InMemoryPayoutRequestStore();
+        var older = CreateRequest(payeeId, PayoutRequestState.Submitted, DateTimeOffset.UtcNow.AddMinutes(-1));
+        var latest = CreateRequest(payeeId, PayoutRequestState.Cancelled, DateTimeOffset.UtcNow);
+        store.Add(older);
+        store.Add(latest);
+        store.Add(CreateRequest(Guid.NewGuid(), PayoutRequestState.Submitted, DateTimeOffset.UtcNow.AddMinutes(1)));
+        var handler = new ListMyPayoutRequestsQueryHandler(store);
+
+        var result = await handler.Handle(new ListMyPayoutRequestsQuery(payeeId, 10), CancellationToken.None);
+
+        result.Select(item => item.Id).Should().Equal(latest.Id, older.Id);
+    }
+
+    [Fact]
+    public void ValidatorRejectsAnEmptyIdempotencyKeyOrNonPositiveAmount()
+    {
+        var validator = new CreateMyPayoutRequestCommandValidator();
+
+        var result = validator.Validate(new CreateMyPayoutRequestCommand(
+            new CreateMyPayoutRequestRequest(0, string.Empty)));
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    private static ActorContextAccessor AuthenticatedAccessor(Guid actorId)
+    {
+        var accessor = new ActorContextAccessor();
+        accessor.SetActorContext(new ActorContext
+        {
+            ActorKind = ActorKind.User,
+            SubjectId = actorId.ToString(),
+            TenantId = Guid.NewGuid(),
+            Roles = new HashSet<string>(),
+            Permissions = new HashSet<string>(),
+            TypedAttributes = ActorAttributes.Empty,
+            IsAuthenticated = true
+        });
+        return accessor;
+    }
+
+    private static EconomyWalletSummaryDto CreateWallet(
+        Guid walletId,
+        long withdrawableHard = 1_000,
+        WalletLifecycleState state = WalletLifecycleState.Active) => new(
+        WalletId: walletId,
+        State: state,
+        CreatedAt: DateTimeOffset.UtcNow,
+        PendingHard: 0,
+        PendingSoft: 0,
+        PurchasedHard: 0,
+        EarnedHard: 0,
+        RestrictedHard: 0,
+        Soft: 0,
+        HeldHard: 0,
+        HeldSoft: 0,
+        AvailableHardToSpend: 0,
+        AvailableSoftToSpend: 0,
+        WithdrawableHard: withdrawableHard,
+        OutstandingHardDebt: 0,
+        ProjectionRebuiltAt: DateTimeOffset.UtcNow,
+        SourceJournalSequence: 0);
+
+    private static PayoutRequest CreateRequest(
+        Guid payeeId,
+        PayoutRequestState state,
+        DateTimeOffset? createdAt = null)
+    {
+        var timestamp = createdAt ?? DateTimeOffset.UtcNow;
+        return new PayoutRequest(
+            Guid.NewGuid(),
+            new IdempotencyKey($"request-{Guid.NewGuid():N}"),
+            new string('a', 64),
+            payeeId,
+            new WalletId(Guid.NewGuid()),
+            new CoinAmount(CurrencyCode.HardCoin, 250),
+            state,
+            1,
+            timestamp,
+            timestamp);
+    }
+
+    private sealed class WalletSender(EconomyWalletSummaryDto wallet) : ISender
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default) =>
+            request is GetMyEconomyWalletQuery
+                ? Task.FromResult((TResponse)(object)wallet)
+                : throw new InvalidOperationException($"Unexpected request {request.GetType().Name}.");
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest => throw new InvalidOperationException("No void request is expected.");
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("No dynamic request is expected.");
+    }
+
+    private sealed class InMemoryPayoutRequestStore : IPayoutRequestStore
+    {
+        private readonly List<PayoutRequest> _items = [];
+
+        public IReadOnlyList<PayoutRequest> Items => _items;
+
+        public PayoutRequest? FindReplay(Guid payeeId, string idempotencyKey, string requestHash)
+        {
+            var item = _items.SingleOrDefault(candidate =>
+                candidate.PayeeId == payeeId && candidate.IdempotencyKey.Value == idempotencyKey);
+            if (item is null)
+                return null;
+            if (!string.Equals(item.RequestHash, requestHash, StringComparison.Ordinal))
+                throw new PayoutRequestReplayConflictException("Payout request idempotency key was reused with different inputs.");
+            return item;
+        }
+
+        public void Add(PayoutRequest request)
+        {
+            if (_items.Any(item =>
+                    item.PayeeId == request.PayeeId && item.IdempotencyKey.Value == request.IdempotencyKey.Value))
+                throw new PayoutRequestReplayConflictException("Payout request idempotency key was reused.");
+            _items.Add(request);
+        }
+
+        public PayoutRequest GetForPayee(Guid requestId, Guid payeeId) => _items.Single(item => item.Id == requestId && item.PayeeId == payeeId);
+
+        public IReadOnlyList<PayoutRequest> ListForPayee(Guid payeeId, int take) => _items
+            .Where(item => item.PayeeId == payeeId)
+            .OrderByDescending(item => item.CreatedAt)
+            .ThenByDescending(item => item.Id)
+            .Take(take)
+            .ToArray();
+
+        public PayoutRequest Update(PayoutRequest request, long expectedVersion)
+        {
+            var index = _items.FindIndex(item => item.Id == request.Id);
+            if (index < 0 || _items[index].Version != expectedVersion)
+                throw new PayoutRequestStaleCommandException("Payout request version is stale.");
+            _items[index] = request;
+            return request;
+        }
+    }
+}

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
@@ -284,16 +284,28 @@ public sealed class SelfServicePayoutRequestTests
 
     private sealed class WalletSender(EconomyWalletSummaryDto? wallet) : ISender
     {
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default) =>
-            request is GetMyEconomyWalletQuery
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return request is GetMyEconomyWalletQuery
                 ? Task.FromResult((TResponse)(object?)wallet!)
                 : throw new InvalidOperationException($"Unexpected request {request.GetType().Name}.");
+        }
 
         public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
-            where TRequest : IRequest => throw new InvalidOperationException("No void request is expected.");
+            where TRequest : IRequest
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(request);
+            throw new InvalidOperationException("No void request is expected.");
+        }
 
-        public Task<object?> Send(object request, CancellationToken cancellationToken = default) =>
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ArgumentNullException.ThrowIfNull(request);
             throw new InvalidOperationException("No dynamic request is expected.");
+        }
     }
 
     private sealed class InMemoryPayoutRequestStore : IPayoutRequestStore
@@ -307,9 +319,13 @@ public sealed class SelfServicePayoutRequestTests
             var item = _items.SingleOrDefault(candidate =>
                 candidate.PayeeId == payeeId && candidate.IdempotencyKey.Value == idempotencyKey);
             if (item is null)
+            {
                 return null;
+            }
             if (!string.Equals(item.RequestHash, requestHash, StringComparison.Ordinal))
+            {
                 throw new PayoutRequestReplayConflictException("Payout request idempotency key was reused with different inputs.");
+            }
             return item;
         }
 
@@ -317,7 +333,9 @@ public sealed class SelfServicePayoutRequestTests
         {
             if (_items.Any(item =>
                     item.PayeeId == request.PayeeId && item.IdempotencyKey.Value == request.IdempotencyKey.Value))
+            {
                 throw new PayoutRequestReplayConflictException("Payout request idempotency key was reused.");
+            }
             _items.Add(request);
         }
 
@@ -334,7 +352,9 @@ public sealed class SelfServicePayoutRequestTests
         {
             var index = _items.FindIndex(item => item.Id == request.Id);
             if (index < 0 || _items[index].Version != expectedVersion)
+            {
                 throw new PayoutRequestStaleCommandException("Payout request version is stale.");
+            }
             _items[index] = request;
             return request;
         }

--- a/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Payouts.UnitTests/SelfServicePayoutRequestTests.cs
@@ -127,6 +127,28 @@ public sealed class SelfServicePayoutRequestTests
     }
 
     [Fact]
+    public async Task CancelRequiresAnAuthenticatedTenantActor()
+    {
+        var handler = new CancelMyPayoutRequestCommandHandler(
+            new ActorContextAccessor(),
+            new InMemoryPayoutRequestStore());
+
+        await FluentActions.Invoking(() => handler.Handle(
+                new CancelMyPayoutRequestCommand(Guid.NewGuid()), CancellationToken.None))
+            .Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public void CancelRejectsAClockThatMovesBackwards()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        var request = CreateRequest(Guid.NewGuid(), PayoutRequestState.Submitted, timestamp);
+
+        FluentActions.Invoking(() => request.Cancel(timestamp.AddSeconds(-1)))
+            .Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public async Task ListReturnsOnlyThePayeesRequests()
     {
         var payeeId = Guid.NewGuid();
@@ -141,6 +163,10 @@ public sealed class SelfServicePayoutRequestTests
         var result = await handler.Handle(new ListMyPayoutRequestsQuery(payeeId, 10), CancellationToken.None);
 
         result.Select(item => item.Id).Should().Equal(latest.Id, older.Id);
+        result.Should().OnlyContain(item => item.HardCoinUnits == 250);
+        result.Select(item => item.State).Should().Equal(PayoutRequestState.Cancelled, PayoutRequestState.Submitted);
+        result[0].CreatedAt.Should().Be(latest.CreatedAt);
+        result[0].UpdatedAt.Should().Be(latest.UpdatedAt);
     }
 
     [Fact]


### PR DESCRIPTION
Adds an actor-scoped payout-request intent API and PostgreSQL security-definer persistence. No provider, reservation, transfer, or startup requirement is enabled.\n\nValidation: API build; 11 payout unit tests; 8 API tests. PostgreSQL migration tests run in the Economy CI gate.