### PR TITLE
fix(economy): allow reclaim fee fragment pairs

### DIFF
--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.Security.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.Security.cs
@@ -1,0 +1,161 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GameGuild.API.Database.Migrations;
+
+public partial class AllowBountyReclaimFeeFragmentPairs
+{
+    private static void InstallBountyReclaimFeeFragmentValidation(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(
+            """
+            CREATE FUNCTION economy_private.validate_bounty_reclaim_posting_lines_v2(p_lines jsonb)
+            RETURNS boolean
+            LANGUAGE plpgsql
+            IMMUTABLE
+            STRICT
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+            DECLARE
+                line_count integer;
+                pair_index integer;
+                currency integer;
+                escrow_account integer;
+                fee_account integer;
+                debit_line jsonb;
+                credit_line jsonb;
+                credit_provenance integer;
+                credit_account integer;
+                return_wallet_id text;
+                fee_pair_seen boolean := false;
+            BEGIN
+                IF jsonb_typeof(p_lines) <> 'array' THEN
+                    RETURN false;
+                END IF;
+
+                line_count := jsonb_array_length(p_lines);
+                IF line_count < 2 OR line_count % 2 <> 0 THEN
+                    RETURN false;
+                END IF;
+
+                currency := (p_lines->0->>'currency')::integer;
+                IF currency NOT IN (1, 2) THEN
+                    RETURN false;
+                END IF;
+                escrow_account := CASE currency WHEN 1 THEN 9 ELSE 10 END;
+                fee_account := CASE currency WHEN 1 THEN 14 ELSE 6 END;
+
+                IF EXISTS (
+                    SELECT 1
+                    FROM jsonb_array_elements(p_lines) AS line
+                    WHERE NULLIF(line->>'id', '')::uuid IS NULL
+                       OR NULLIF(line->>'account_id', '')::uuid IS NULL
+                       OR COALESCE((line->>'amount_units')::bigint, 0) <= 0
+                       OR COALESCE((line->>'side')::integer, 0) NOT IN (1, 2)
+                       OR COALESCE((line->>'currency')::integer, 0) <> currency
+                       OR COALESCE((line->>'account_code')::integer, 0) NOT BETWEEN 1 AND 15) THEN
+                    RETURN false;
+                END IF;
+
+                FOR pair_index IN 0..(line_count / 2 - 1) LOOP
+                    debit_line := p_lines->(pair_index * 2);
+                    credit_line := p_lines->(pair_index * 2 + 1);
+                    IF NOT economy_private.line_matches_v2(
+                        debit_line, 1, escrow_account, currency, false, NULL)
+                       OR (debit_line->>'amount_units')::bigint <> (credit_line->>'amount_units')::bigint THEN
+                        RETURN false;
+                    END IF;
+
+                    IF NULLIF(credit_line->>'wallet_id', '') IS NULL THEN
+                        fee_pair_seen := true;
+                        IF NOT economy_private.line_matches_v2(
+                            credit_line, 2, fee_account, currency, false, NULL) THEN
+                            RETURN false;
+                        END IF;
+                        CONTINUE;
+                    END IF;
+
+                    IF fee_pair_seen THEN
+                        RETURN false;
+                    END IF;
+
+                    credit_provenance := NULLIF(credit_line->>'provenance', '')::integer;
+                    credit_account := (credit_line->>'account_code')::integer;
+                    IF credit_provenance IS NULL
+                       OR (credit_line->>'side')::integer <> 2
+                       OR (credit_line->>'currency')::integer <> currency THEN
+                        RETURN false;
+                    END IF;
+
+                    IF return_wallet_id IS NULL THEN
+                        return_wallet_id := credit_line->>'wallet_id';
+                    ELSIF return_wallet_id <> credit_line->>'wallet_id' THEN
+                        RETURN false;
+                    END IF;
+
+                    IF currency = 1 AND NOT (
+                        credit_provenance IN (1, 2)
+                        AND ((credit_provenance = 2 AND credit_account = 3)
+                             OR (credit_provenance = 1 AND credit_account = 2))) THEN
+                        RETURN false;
+                    END IF;
+                    IF currency = 2 AND NOT (
+                        credit_provenance BETWEEN 3 AND 7 AND credit_account = 4) THEN
+                        RETURN false;
+                    END IF;
+                END LOOP;
+
+                RETURN true;
+            END
+            $function$;
+
+            CREATE OR REPLACE FUNCTION economy_private.validate_posting_lines_v1(
+                p_template_kind integer,
+                p_lines jsonb)
+            RETURNS boolean
+            LANGUAGE sql
+            IMMUTABLE
+            STRICT
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+                SELECT CASE p_template_kind
+                    WHEN 22 THEN economy_private.validate_bounty_escrow_posting_lines_v1(p_lines)
+                    WHEN 23 THEN economy_private.validate_bounty_claim_posting_lines_v1(p_lines)
+                    WHEN 24 THEN economy_private.validate_bounty_reclaim_posting_lines_v2(p_lines)
+                    ELSE economy_private.validate_posting_lines_legacy_v1(p_template_kind, p_lines)
+                END
+            $function$;
+
+            ALTER FUNCTION economy_private.validate_bounty_reclaim_posting_lines_v2(jsonb)
+                OWNER TO gameguild_economy_procedure_owner;
+            ALTER FUNCTION economy_private.validate_posting_lines_v1(integer,jsonb)
+                OWNER TO gameguild_economy_procedure_owner;
+            REVOKE ALL ON FUNCTION economy_private.validate_bounty_reclaim_posting_lines_v2(jsonb) FROM PUBLIC;
+            REVOKE ALL ON FUNCTION economy_private.validate_posting_lines_v1(integer,jsonb) FROM PUBLIC;
+            """);
+    }
+
+    private static void RestoreBountyReclaimFeeFragmentValidation(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.Sql(
+            """
+            CREATE OR REPLACE FUNCTION economy_private.validate_posting_lines_v1(
+                p_template_kind integer,
+                p_lines jsonb)
+            RETURNS boolean
+            LANGUAGE sql
+            IMMUTABLE
+            STRICT
+            SET search_path = pg_catalog, economy_private
+            AS $function$
+                SELECT CASE p_template_kind
+                    WHEN 22 THEN economy_private.validate_bounty_escrow_posting_lines_v1(p_lines)
+                    WHEN 23 THEN economy_private.validate_bounty_claim_posting_lines_v1(p_lines)
+                    WHEN 24 THEN economy_private.validate_bounty_reclaim_posting_lines_v1(p_lines)
+                    ELSE economy_private.validate_posting_lines_legacy_v1(p_template_kind, p_lines)
+                END
+            $function$;
+
+            DROP FUNCTION economy_private.validate_bounty_reclaim_posting_lines_v2(jsonb);
+            """);
+    }
+}

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.Security.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.Security.cs
@@ -2,9 +2,9 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace GameGuild.API.Database.Migrations;
 
-public partial class AllowBountyReclaimFeeFragmentPairs
+internal static class BountyReclaimFeeFragmentValidationSql
 {
-    private static void InstallBountyReclaimFeeFragmentValidation(MigrationBuilder migrationBuilder)
+    internal static void Install(MigrationBuilder migrationBuilder)
     {
         migrationBuilder.Sql(
             """
@@ -134,7 +134,7 @@ public partial class AllowBountyReclaimFeeFragmentPairs
             """);
     }
 
-    private static void RestoreBountyReclaimFeeFragmentValidation(MigrationBuilder migrationBuilder)
+    internal static void Restore(MigrationBuilder migrationBuilder)
     {
         migrationBuilder.Sql(
             """

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.cs
@@ -1,0 +1,18 @@
+using GameGuild.API.Database;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GameGuild.API.Database.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+[Migration("20260811152000_AllowBountyReclaimFeeFragmentPairs")]
+public partial class AllowBountyReclaimFeeFragmentPairs : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder) =>
+        InstallBountyReclaimFeeFragmentValidation(migrationBuilder);
+
+    protected override void Down(MigrationBuilder migrationBuilder) =>
+        RestoreBountyReclaimFeeFragmentValidation(migrationBuilder);
+}

--- a/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.cs
+++ b/apps/api/Source/GameGuild.API/Database/Migrations/20260811152000_AllowBountyReclaimFeeFragmentPairs.cs
@@ -11,8 +11,8 @@ namespace GameGuild.API.Database.Migrations;
 public partial class AllowBountyReclaimFeeFragmentPairs : Migration
 {
     protected override void Up(MigrationBuilder migrationBuilder) =>
-        InstallBountyReclaimFeeFragmentValidation(migrationBuilder);
+        BountyReclaimFeeFragmentValidationSql.Install(migrationBuilder);
 
     protected override void Down(MigrationBuilder migrationBuilder) =>
-        RestoreBountyReclaimFeeFragmentValidation(migrationBuilder);
+        BountyReclaimFeeFragmentValidationSql.Restore(migrationBuilder);
 }

--- a/apps/api/Source/Modules/GameGuild.Economy/Posting/PostingValidation.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy/Posting/PostingValidation.cs
@@ -302,6 +302,7 @@ public static class PostingMatrix
             return;
         }
 
+        var feeOrBurnPairSeen = false;
         for (var index = 0; index < lines.Length; index += 2)
         {
             var debit = lines[index];
@@ -320,16 +321,17 @@ public static class PostingMatrix
 
             if (credit.WalletId is null)
             {
+                feeOrBurnPairSeen = true;
                 var expectedFeeAccount = currency == CurrencyCode.HardCoin
                     ? EconomyAccountCode.FeeRevenueHard
                     : EconomyAccountCode.SoftCoinReserve;
                 Match(credit, EntrySide.Credit, expectedFeeAccount, currency, false, null, errors);
-                if (index + 2 != lines.Length)
-                    Add(errors, PostingErrorCode.InvalidAccountShape,
-                        "The bounty reclaim fee/burn pair must be the last posting pair.");
                 continue;
             }
 
+            if (feeOrBurnPairSeen)
+                Add(errors, PostingErrorCode.InvalidAccountShape,
+                    "Bounty reclaim return pairs cannot follow a fee or burn pair.");
             ValidateLiability(credit, EntrySide.Credit, credit.Provenance, errors);
             if (credit.Provenance is null)
                 Add(errors, PostingErrorCode.InvalidProvenance,

--- a/apps/api/Source/Modules/GameGuild.Economy/Posting/PostingValidation.cs
+++ b/apps/api/Source/Modules/GameGuild.Economy/Posting/PostingValidation.cs
@@ -330,8 +330,10 @@ public static class PostingMatrix
             }
 
             if (feeOrBurnPairSeen)
+            {
                 Add(errors, PostingErrorCode.InvalidAccountShape,
                     "Bounty reclaim return pairs cannot follow a fee or burn pair.");
+            }
             ValidateLiability(credit, EntrySide.Credit, credit.Provenance, errors);
             if (credit.Provenance is null)
                 Add(errors, PostingErrorCode.InvalidProvenance,

--- a/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyWriterParityPostgreSqlMigrationTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Database/EconomyWriterParityPostgreSqlMigrationTests.cs
@@ -121,6 +121,39 @@ public sealed class EconomyWriterParityPostgreSqlMigrationTests
             CanonicalLines(PostingTemplateKind.ProviderConvertedSoftReversal))).Should().BeTrue();
     }
 
+    [DockerFact]
+    public async Task BountyReclaimValidatorAcceptsFeePairsAfterReturnPairs()
+    {
+        await using var container = new PostgreSqlBuilder()
+            .WithImage("postgres:16-alpine")
+            .WithDatabase("economy_writer_bounty_fee_validation")
+            .WithUsername("test")
+            .WithPassword("test")
+            .WithCleanUp(true)
+            .Build();
+        await container.StartAsync();
+
+        await using var context = new ApplicationDbContext(
+            new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseNpgsql(container.GetConnectionString())
+                .Options);
+        await context.Database.MigrateAsync();
+
+        await using var connection = new NpgsqlConnection(container.GetConnectionString());
+        await connection.OpenAsync();
+
+        var lines = Enumerable.Range(0, 10)
+            .SelectMany(index => new[]
+            {
+                Line(1, 9, 1, 1),
+                index < 8
+                    ? Line(2, 2, 1, 1, DestinationWallet, 1)
+                    : Line(2, 14, 1, 1)
+            })
+            .ToList();
+
+        (await ValidateAsync(connection, PostingTemplateKind.BountyReclaim, lines)).Should().BeTrue();
+    }
     private static async Task<bool> ValidateAsync(
         NpgsqlConnection connection,
         PostingTemplateKind kind,

--- a/apps/api/tests/GameGuild.Economy.Bounties.UnitTests/BountyReclaimPostingFactoryTests.cs
+++ b/apps/api/tests/GameGuild.Economy.Bounties.UnitTests/BountyReclaimPostingFactoryTests.cs
@@ -83,6 +83,34 @@ public sealed class BountyReclaimPostingFactoryTests
     }
 
     [Fact]
+    public void Create_AllowsMultipleFeePairsAfterAllReturnPairs()
+    {
+        var posterId = Guid.NewGuid();
+        var posterWalletId = WalletId.New();
+        var request = new DurableBountyReclaimRequest(
+            BountyId.New(), posterId, posterWalletId, ReclaimedAt,
+            new IdempotencyKey("multi-fee-bounty-reclaim"), Authority(posterId),
+            new ReserveVersion(2), new PolicyVersion(3));
+        var escrow = CreateEscrow(
+            request.BountyId,
+            posterId,
+            posterWalletId,
+            CurrencyCode.HardCoin,
+            200_000,
+            Enumerable.Range(0, 10).Select(_ => Fragment(1, ProvenanceKind.PurchasedHard)).ToArray());
+
+        var posting = BountyReclaimPostingFactory.Create(escrow, request);
+
+        posting.Posting.Lines.Should().HaveCount(20);
+        posting.Posting.Lines
+            .Where(line => line.Side == EntrySide.Credit && line.WalletId == posterWalletId)
+            .Should().HaveCount(8);
+        posting.Posting.Lines
+            .Where(line => line.Side == EntrySide.Credit && line.Account == EconomyAccountCode.FeeRevenueHard)
+            .Should().HaveCount(2);
+    }
+
+    [Fact]
     public void Create_RejectsAReclaimBeforeTheBountyExpires()
     {
         var posterId = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- accepts multiple contiguous bounty reclaim fee or burn pairs after return pairs
- keeps the domain posting validator and PostgreSQL security function in parity
- covers factory output and PostgreSQL writer validation

## Verification
- dotnet build apps/api/tests/GameGuild.Economy.Bounties.UnitTests/GameGuild.Economy.Bounties.UnitTests.csproj -c Release --no-restore
- dotnet test apps/api/tests/GameGuild.Economy.Bounties.UnitTests/GameGuild.Economy.Bounties.UnitTests.csproj -c Release --no-restore --filter FullyQualifiedName~BountyReclaimPostingFactoryTests
- dotnet build apps/api/tests/GameGuild.API.UnitTests/GameGuild.API.UnitTests.csproj -c Release --no-restore