### PR TITLE
fix(ci): restore EF tool before release migrations

### DIFF
--- a/scripts/ci/tests/verify-economy.sh
+++ b/scripts/ci/tests/verify-economy.sh
@@ -255,6 +255,7 @@ test_economy_gate_migrates_one_template_and_clones_isolated_test_databases() {
 
   grep -Fq "gate_stage='postgres-economy-template'" "$gate" || return 1
   grep -Fq "economy_template_database='economy_tests_template'" "$gate" || return 1
+  grep -Fq 'run dotnet tool restore' "$gate" || return 1
   grep -Fq 'dotnet ef database update' "$gate" || return 1
   grep -Fq 'export ECONOMY_POSTGRES_TEMPLATE_DATABASE="$economy_template_database"' "$gate" || return 1
   grep -Fq 'ECONOMY_POSTGRES_TEMPLATE_DATABASE' "$database_support" || return 1

--- a/scripts/ci/verify-economy.sh
+++ b/scripts/ci/verify-economy.sh
@@ -514,6 +514,7 @@ fi
 
 gate_stage='build'
 run dotnet restore apps/api/GameGuild.sln --nologo
+run dotnet tool restore
 if [[ "$gate_profile" == full ]]; then
   run dotnet build apps/api/GameGuild.sln -c Release --no-restore --nologo --verbosity minimal \
     "${dotnet_build_isolation[@]}" \


### PR DESCRIPTION
## Summary

Restores the repository-local dotnet-ef tool before the Economy release gate attempts to migrate its disposable PostgreSQL template.

## Evidence

- Reproduced in the production gate run: dotnet ef database update failed because dotnet tool restore had not run.
- bash scripts/ci/tests/verify-economy.sh: 57 passed, 0 failed.
- dotnet tool restore: restored dotnet-ef 10.0.9 successfully.