### PR TITLE
fix(api): seed canonical authorization policies at startup

### DIFF
--- a/apps/api/Source/GameGuild.API/Database/DatabaseSeeder.cs
+++ b/apps/api/Source/GameGuild.API/Database/DatabaseSeeder.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using GameGuild.Identity.Authorization;
 using GameGuild.Identity.Tenants;
 using GameGuild.LaunchPad;
 using GameGuild.Projects;
@@ -24,6 +25,8 @@ public static class DatabaseSeeder
     {
         // Ensure ApplicationDbContext is registered (validates DI configuration)
         var dbContext = serviceProvider.GetRequiredService<ApplicationDbContext>();
+        var policyDefinitionSeeder = serviceProvider.GetRequiredService<PolicyDefinitionSeeder>();
+        await policyDefinitionSeeder.SeedAsync().ConfigureAwait(false);
 
         // Try to get Identity managers - they may not be registered in all configurations
         var userManager = serviceProvider.GetService<UserManager<LegacyIdentityUser>>();

--- a/apps/api/tests/GameGuild.API.UnitTests/Database/DatabaseSeederTests.cs
+++ b/apps/api/tests/GameGuild.API.UnitTests/Database/DatabaseSeederTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using GameGuild.API.Database;
+using GameGuild.Identity.Authorization;
 using GameGuild.Identity.Tenants;
 using GameGuild.Identity.Users;
 using GameGuild.LaunchPad;
@@ -31,12 +32,29 @@ public sealed class DatabaseSeederTests
         services.AddSingleton<IConfiguration>(configuration);
         services.AddSingleton<ILogger<ApplicationDbContext>>(logger);
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        AddPolicySeeder(services);
 
         await using var provider = services.BuildServiceProvider();
 
         await DatabaseSeeder.SeedAsync(provider);
 
         logger.Messages.Where(message => message.Level >= LogLevel.Warning).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SeedAsync_Should_Create_The_Canonical_SystemAdmin_Policy()
+    {
+        var services = CreateSeederServices("UnitTestAdmin123!");
+        await using var provider = services.BuildServiceProvider();
+
+        await DatabaseSeeder.SeedAsync(provider);
+
+        var dbContext = provider.GetRequiredService<ApplicationDbContext>();
+        var policy = await dbContext.Set<PolicyDefinitionEntity>()
+            .SingleAsync(candidate => candidate.PolicyName == Policies.SystemAdmin && candidate.TenantId == null);
+
+        policy.RequiredRolesJson.Should().Be("[\"SystemAdmin\"]");
+        policy.PolicyVersion.Should().Be(PolicyDefinitionSeeder.CurrentPolicyVersion);
     }
 
     [Fact]
@@ -159,8 +177,17 @@ public sealed class DatabaseSeederTests
         services.AddSingleton<IConfiguration>(configuration);
         services.AddSingleton<ILogger<ApplicationDbContext>, CapturingLogger<ApplicationDbContext>>();
         services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        AddPolicySeeder(services);
 
         return services;
+    }
+
+    private static void AddPolicySeeder(IServiceCollection services)
+    {
+        services.AddLogging();
+        services.AddScoped<IApplicationDbContext>(provider => provider.GetRequiredService<ApplicationDbContext>());
+        services.AddScoped<IPolicyDefinitionRepository, PolicyDefinitionRepository>();
+        services.AddScoped<PolicyDefinitionSeeder>();
     }
 
     private sealed class CapturingLogger<T> : ILogger<T>

--- a/apps/api/tests/GameGuild.Resources.IntegrationTests/Infrastructure/PostgreSqlWebApplicationFactory.cs
+++ b/apps/api/tests/GameGuild.Resources.IntegrationTests/Infrastructure/PostgreSqlWebApplicationFactory.cs
@@ -85,6 +85,7 @@ public class PostgreSqlWebApplicationFactory : WebApplicationFactory<GameGuild.A
         using var scope = host.Services.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         context.Database.Migrate();
+        DatabaseSeeder.SeedAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         SeedAuthorizationFixtures(context);
         return host;
     }


### PR DESCRIPTION
## Summary
- invoke the registered canonical policy seeder during normal database startup
- make the Resources PostgreSQL integration host execute the same production seeding path
- lock the SystemAdmin policy name, role definition, and canonical version in DatabaseSeeder tests

## Root cause
The fail-closed database policy provider replaced static fallbacks, but startup never invoked PolicyDefinitionSeeder. Migrated databases could therefore deny every registered policy, including SystemAdmin.

## Verification
- ResourcesAdmin_SystemAdmin_Succeeds: red (403) before, green after
- GameGuild.Resources.IntegrationTests: 43 passed
- DatabaseSeederTests: 5 passed
- PolicyDefinitionSeederTests: 3 passed
- GameGuild.API.UnitTests: 632 passed
- git diff --check