### PR TITLE
fix(ci): build API dependencies before publish

### DIFF
--- a/scripts/ci/tests/verify-economy.sh
+++ b/scripts/ci/tests/verify-economy.sh
@@ -193,12 +193,13 @@ test_economy_unit_tests_bound_parallelism_without_global_serialization() {
   grep -Fq 'adminBuilder.CommandTimeout = 120;' "$database_support"
 }
 
-test_economy_gate_builds_release_targets_strictly_once() {
+test_economy_gate_builds_release_targets_before_packaging() {
   local gate="$ci_dir/verify-economy.sh"
 
   grep -Fq 'dotnet build apps/api/GameGuild.sln -c Release --no-restore --nologo --verbosity minimal' "$gate" || return 1
   ! grep -Fq 'dotnet build apps/api/Source/GameGuild.API/GameGuild.API.csproj' "$gate" || return 1
-  grep -Fq 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-build --no-restore' "$gate" || return 1
+  grep -Fq 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore' "$gate" || return 1
+  ! grep -Fq 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-build' "$gate" || return 1
   grep -Fq 'provider_build_arguments=(--no-build --no-restore)' "$gate" || return 1
   grep -Fq 'dotnet_build_isolation=(-m:1 -p:UseSharedCompilation=false)' "$gate" || return 1
   grep -Fq -- '-p:TreatWarningsAsErrors=true' "$gate" || return 1
@@ -729,7 +730,7 @@ run_test 'Economy gate bounds hung tests and records timings' test_economy_gate_
 run_test 'Economy gate supports fast PR and full release profiles' test_economy_gate_supports_fast_pr_and_full_release_profiles
 run_test 'Economy gate batches whole-solution tests' test_economy_gate_batches_whole_solution_tests
 run_test 'Economy unit tests bound parallelism without global serialization' test_economy_unit_tests_bound_parallelism_without_global_serialization
-run_test 'Economy gate builds strict release targets once' test_economy_gate_builds_release_targets_strictly_once
+run_test 'Economy gate builds release targets before packaging' test_economy_gate_builds_release_targets_before_packaging
 run_test 'Economy gate rejects nested PostgreSQL Testcontainers' test_economy_gate_rejects_nested_postgres_testcontainers
 run_test 'Economy gate isolates global roles from application databases' test_economy_gate_isolates_global_economy_roles_from_application_databases
 run_test 'full gate isolates API migration tests from the Economy template' test_full_gate_isolates_api_migration_tests_from_the_economy_template

--- a/scripts/ci/tests/verify-economy.sh
+++ b/scripts/ci/tests/verify-economy.sh
@@ -200,6 +200,7 @@ test_economy_gate_builds_release_targets_before_packaging() {
   ! grep -Fq 'dotnet build apps/api/Source/GameGuild.API/GameGuild.API.csproj' "$gate" || return 1
   grep -Fq 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore' "$gate" || return 1
   ! grep -Fq 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-build' "$gate" || return 1
+  grep -A3 -F 'dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj' "$gate" | grep -Fq -- '-p:TreatWarningsAsErrors=true' || return 1
   grep -Fq 'provider_build_arguments=(--no-build --no-restore)' "$gate" || return 1
   grep -Fq 'dotnet_build_isolation=(-m:1 -p:UseSharedCompilation=false)' "$gate" || return 1
   grep -Fq -- '-p:TreatWarningsAsErrors=true' "$gate" || return 1

--- a/scripts/ci/verify-economy.sh
+++ b/scripts/ci/verify-economy.sh
@@ -681,7 +681,9 @@ if [[ "$gate_profile" == full ]]; then
   publish_directory="$artifact_root/publish/api"
   # Some API project references are intentionally not solution members. Build
   # during publish so their output is always materialized before packaging.
-  run dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore --nologo --output "$publish_directory"
+  run dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore --nologo --output "$publish_directory" \
+    "${dotnet_build_isolation[@]}" \
+    -p:TreatWarningsAsErrors=true
   api_port="$(get_ephemeral_port)"
   export ASPNETCORE_ENVIRONMENT=Development
   export ASPNETCORE_URLS="http://127.0.0.1:$api_port"

--- a/scripts/ci/verify-economy.sh
+++ b/scripts/ci/verify-economy.sh
@@ -679,7 +679,9 @@ if [[ "$gate_profile" == full ]]; then
 {
   gate_stage='openapi-client'
   publish_directory="$artifact_root/publish/api"
-  run dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-build --no-restore --nologo --output "$publish_directory"
+  # Some API project references are intentionally not solution members. Build
+  # during publish so their output is always materialized before packaging.
+  run dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore --nologo --output "$publish_directory"
   api_port="$(get_ephemeral_port)"
   export ASPNETCORE_ENVIRONMENT=Development
   export ASPNETCORE_URLS="http://127.0.0.1:$api_port"


### PR DESCRIPTION
## Summary
- build the API during the release publish step while reusing the existing restore
- materialize out-of-solution project references in Release before packaging
- update the shell regression test to prevent reintroducing --no-build on publish

## Validation
- bash scripts/ci/tests/verify-economy.sh (57 passed)
- dotnet restore apps/api/GameGuild.sln --nologo
- dotnet build apps/api/GameGuild.sln -c Release --no-restore --nologo --verbosity minimal -m:1 -p:UseSharedCompilation=false -p:TreatWarningsAsErrors=true (0 warnings, 0 errors)
- dotnet publish apps/api/Source/GameGuild.API/GameGuild.API.csproj -c Release --no-restore --nologo --output artifacts/test-results/economy/publish/api-local-fix