### PR TITLE
fix(web): trust server conversion fee policy

### DIFF
--- a/apps/web/src/lib/economy/actions.test.ts
+++ b/apps/web/src/lib/economy/actions.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  getToken: vi.fn(),
+  createServerClient: vi.fn(),
+  postEconomyConversionsHardToSoft: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/auth', () => ({
+  auth: mocks.auth,
+  getToken: mocks.getToken,
+}));
+
+vi.mock('@game-guild/client', () => ({
+  createServerClient: mocks.createServerClient,
+  GeneratedApi: {
+    EconomyModule: class {
+      postEconomyConversionsHardToSoft = mocks.postEconomyConversionsHardToSoft;
+    },
+  },
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+import { convertHardToSoftAction } from './actions';
+
+describe('economy actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.auth.mockResolvedValue({ user: { id: 'user-1' }, tenantId: 'tenant-1' });
+    mocks.getToken.mockResolvedValue('access-token');
+    mocks.createServerClient.mockReturnValue({});
+    mocks.postEconomyConversionsHardToSoft.mockResolvedValue({ ok: true, data: {} });
+  });
+
+  it('lets the server policy calculate the hard-to-soft conversion fee', async () => {
+    await expect(convertHardToSoftAction(25, ' conversion-1 ')).resolves.toEqual({
+      success: true,
+      message: 'Conversion recorded in the Economy journal.',
+    });
+
+    expect(mocks.postEconomyConversionsHardToSoft).toHaveBeenCalledWith({
+      principalHardCoinUnits: 25,
+      idempotencyKey: 'conversion-1',
+    });
+    expect(mocks.revalidatePath).toHaveBeenCalledWith('/', 'layout');
+  });
+});

--- a/apps/web/src/lib/economy/actions.ts
+++ b/apps/web/src/lib/economy/actions.ts
@@ -83,7 +83,6 @@ export async function convertHardToSoftAction(
 
   const result = await economy.postEconomyConversionsHardToSoft({
     principalHardCoinUnits,
-    feeHardCoinUnits: 0,
     idempotencyKey: idempotencyKey.trim(),
   });
   if (!result.ok) return failure(result.error.message || 'The conversion is currently unavailable.');


### PR DESCRIPTION
## Summary
- stop sending the retired client-controlled conversion fee
- let the signed server policy calculate the fee
- cover the generated-client payload with a focused regression test

## Validation
- `pnpm --filter @game-guild/web exec vitest run src/lib/economy/actions.test.ts`
- `pnpm --filter @game-guild/web exec eslint src/lib/economy/actions.ts src/lib/economy/actions.test.ts`
- `pnpm --filter @game-guild/web build`