### PR TITLE
fix(release): unblock Emception browser and security gates

### DIFF
--- a/.github/workflows/emception.yml
+++ b/.github/workflows/emception.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Build all Emception packages
         run: pnpm run build:emception
 
+      - name: Build generated API client
+        run: pnpm --filter @game-guild/client run build
+
       - name: Type-check all Emception packages
         run: pnpm run typecheck:emception
 

--- a/apps/api/Source/Modules/GameGuild.Learning.Courses/Authorization/CourseContentAccessRuleEvaluator.cs
+++ b/apps/api/Source/Modules/GameGuild.Learning.Courses/Authorization/CourseContentAccessRuleEvaluator.cs
@@ -60,7 +60,7 @@ public sealed class CourseContentAccessRuleEvaluator(
         ClaimsPrincipal user,
         Program program)
     {
-        var userId = GetCurrentUserId(user);
+        var userId = ClaimsExtractor.GetUserIdAsGuid(user);
         if (!(user.Identity?.IsAuthenticated ?? false) || userId is not Guid authenticatedUserId)
         {
             return RuleEvaluationResult.Fail("Authenticated learner identity is required");
@@ -87,7 +87,7 @@ public sealed class CourseContentAccessRuleEvaluator(
             return RuleEvaluationResult.Success();
         }
 
-        var userId = GetCurrentUserId(user);
+        var userId = ClaimsExtractor.GetUserIdAsGuid(user);
         if (!(user.Identity?.IsAuthenticated ?? false) || userId is not Guid authenticatedUserId)
         {
             return RuleEvaluationResult.Fail("Authenticated manager identity is required");
@@ -120,9 +120,4 @@ public sealed class CourseContentAccessRuleEvaluator(
         return RuleEvaluationResult.Fail("No course management permission was granted");
     }
 
-    private static Guid? GetCurrentUserId(ClaimsPrincipal user)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        return Guid.TryParse(userId, out var parsedUserId) ? parsedUserId : null;
-    }
 }

--- a/apps/api/Source/Modules/GameGuild.Projects/Controllers/ProjectsController.cs
+++ b/apps/api/Source/Modules/GameGuild.Projects/Controllers/ProjectsController.cs
@@ -713,7 +713,7 @@ public class ProjectsController : BaseApiController {
     _context.Set<ProjectCollaborator>().Add(collaborator);
     await _context.SaveChangesAsync().ConfigureAwait(false);
 
-    _logger.LogInformation("User {AdminId} added collaborator {UserId} to project {ProjectId} with role {Role}", userId, request.UserId, id, collaborator.Role);
+    _logger.LogInformation("User {AdminId} added collaborator {UserId} to project {ProjectId}", userId, request.UserId, id);
 
     return CreatedAtAction(nameof(GetProjectCollaborators), new { id }, new CollaboratorDto {
       Id = collaborator.Id,
@@ -815,7 +815,7 @@ public class ProjectsController : BaseApiController {
 
     await _context.SaveChangesAsync().ConfigureAwait(false);
 
-    _logger.LogInformation("User {AdminId} shared project {ProjectId} with user {TargetUserId} as {Role}", userId, id, request.UserId, request.Role ?? "Viewer");
+    _logger.LogInformation("User {AdminId} shared project {ProjectId} with user {TargetUserId}", userId, id, request.UserId);
 
     return Ok(new { Message = "Project shared", ProjectId = id, UserId = request.UserId, Role = request.Role ?? "Viewer" });
   }

--- a/apps/api/tests/GameGuild.Learning.Courses.UnitTests/CourseContentAccessRuleEvaluatorTests.cs
+++ b/apps/api/tests/GameGuild.Learning.Courses.UnitTests/CourseContentAccessRuleEvaluatorTests.cs
@@ -71,6 +71,31 @@ public sealed class CourseContentAccessRuleEvaluatorTests
     }
 
     [Fact]
+    public async Task Learner_AllowsJwtSubjectClaimWithExistingEnrollmentProgress()
+    {
+        var userId = Guid.NewGuid();
+        var program = new Program { Id = Guid.NewGuid() };
+        _programService
+            .Setup(service => service.GetUserProgressDtoAsync(program.Id, userId))
+            .ReturnsAsync(new UserProgressDto(
+                Guid.NewGuid(),
+                program.Id,
+                userId,
+                0,
+                null,
+                null,
+                null,
+                []));
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim("sub", userId.ToString())],
+            "Bearer"));
+
+        var result = await EvaluateAsync(program, "Learner", user);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Learner_DeniesAuthenticatedUserWithoutEnrollmentProgress()
     {
         var userId = Guid.NewGuid();

--- a/apps/web/scripts/coding-cycle-browser-e2e.mjs
+++ b/apps/web/scripts/coding-cycle-browser-e2e.mjs
@@ -47,6 +47,7 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { existsSync, readFileSync, createWriteStream, rmSync } from "node:fs";
 import { resolve } from "node:path";
@@ -436,7 +437,7 @@ function pipeLog(proc, file) {
 // ---------------------------------------------------------------------------
 
 function unique() {
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return `${Date.now()}-${randomUUID().slice(0, 8)}`;
 }
 
 function formatApiError(error) {

--- a/apps/web/src/app/[locale]/learn/courses/[slug]/activities/[activityId]/coding-activity.test.tsx
+++ b/apps/web/src/app/[locale]/learn/courses/[slug]/activities/[activityId]/coding-activity.test.tsx
@@ -203,7 +203,7 @@ describe('coding activity page', () => {
     expect(screen.getByRole('button', { name: /^Submit$/ })).toBeEnabled();
   });
 
-  it('runs public tests before sending only the session delta in the existing code payload shape', async () => {
+  it('submits the current session delta without recompiling the browser workspace', async () => {
     const delta = [{ path: 'main.cpp', content: 'int main(){}' }];
     const session = stubAssessmentEditor(delta);
     mocks.getCodingAssignmentPublic.mockResolvedValue(makeAssignment());
@@ -214,9 +214,8 @@ describe('coding activity page', () => {
     await screen.findByTestId('mock-assessment-editor');
     fireEvent.click(screen.getByRole('button', { name: /^Submit$/ }));
     await waitFor(() => expect(mocks.submitAssessment).toHaveBeenCalledTimes(1));
-    expect(session.run).toHaveBeenCalledWith('public');
+    expect(session.run).not.toHaveBeenCalled();
     expect(session.getSubmissionDelta).toHaveBeenCalledTimes(1);
-    expect(session.run.mock.invocationCallOrder[0]).toBeLessThan(session.getSubmissionDelta.mock.invocationCallOrder[0]);
     const [, formData] = mocks.submitAssessment.mock.calls[0] as [unknown, FormData];
     expect(formData.get('assessmentId')).toBe('assessment-1');
     expect(formData.get('enrollmentId')).toBe('enrollment-1');

--- a/apps/web/src/components/learning/coding-activity-client.tsx
+++ b/apps/web/src/components/learning/coding-activity-client.tsx
@@ -143,7 +143,9 @@ export function CodingActivityClient({
     if (submitting) return;
     setSubmitting(true);
     try {
-      await sessionRef.current?.run('public');
+      // Submission serializes the current editor state without recompiling it.
+      // Public tests have their own explicit action; repeating a full browser
+      // toolchain run here can keep the form in "Submitting" for over a minute.
       // The assessment session returns only editable public changes plus
       // permitted student-created text files.
       const modified = (await sessionRef.current?.getSubmissionDelta()) ?? [];

--- a/tools/emception/scripts/build-imgui.ts
+++ b/tools/emception/scripts/build-imgui.ts
@@ -10,6 +10,7 @@
  * Depends on SDL3 being already built and deployed to the sysroot.
  */
 
+import { spawnSync } from 'node:child_process';
 import fs from 'fs';
 import path from 'path';
 import { toolchainPaths } from './toolchain/paths.ts';
@@ -28,6 +29,22 @@ shell.config.fatal = true;
 const { lock } = loadToolchainStateSync(ROOT);
 const EMSDK_VERSION = lockedVersion(lock, 'emsdk');
 setupEmsdk(EMSDK_VERSION);
+
+function runEmscriptenTool(tool: 'emcc' | 'emar', args: readonly string[]): void {
+    let executable: string = tool;
+    let invocationArgs = [...args];
+
+    if (process.platform === 'win32') {
+        const python = process.env.EMSDK_PYTHON;
+        if (!python) throw new Error('EMSDK_PYTHON is missing after Emscripten activation.');
+        executable = python;
+        invocationArgs = [path.join(P.emsdk, 'upstream', 'emscripten', `${tool}.py`), ...args];
+    }
+
+    const result = spawnSync(executable, invocationArgs, { env: process.env, stdio: 'inherit' });
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error(`${tool} exited with status ${result.status}.`);
+}
 
 const SOURCE_ROOT = path.join(P.sources, 'imgui');
 const BUILD_DIR = path.join(P.builds, 'imgui');
@@ -80,10 +97,11 @@ const CXXFLAGS = [
     '-Os',
     '-DNDEBUG',               // Disable IM_ASSERT → no __assert_fail import in libimgui.a
     // No -fwasm-exceptions: incompatible with -mno-reference-types (Asyncify).
-    `-I"${SOURCE_DIR}"`,
-    `-I"${SOURCE_DIR}/backends"`,
-    `-isystem "${SYSROOT_INC}"`,  // SDL3 plus copied libc headers are system headers
-].join(' ');
+    `-I${SOURCE_DIR}`,
+    `-I${path.join(SOURCE_DIR, 'backends')}`,
+    '-isystem',
+    SYSROOT_INC,  // SDL3 plus copied libc headers are system headers
+];
 
 // Compile all source files to object files
 const objectFiles: string[] = [];
@@ -93,7 +111,7 @@ for (const src of coreFiles) {
     const srcPath = path.join(SOURCE_DIR, src);
     const objName = path.basename(src, '.cpp') + '.o';
     const objPath = path.join(BUILD_DIR, objName);
-    shell.exec(`emcc ${CXXFLAGS} -c "${srcPath}" -o "${objPath}"`);
+    runEmscriptenTool('emcc', [...CXXFLAGS, '-c', srcPath, '-o', objPath]);
     objectFiles.push(objPath);
 }
 
@@ -106,14 +124,14 @@ for (const src of backendFiles) {
     }
     const objName = path.basename(src, '.cpp') + '.o';
     const objPath = path.join(BUILD_DIR, objName);
-    shell.exec(`emcc ${CXXFLAGS} -c "${srcPath}" -o "${objPath}"`);
+    runEmscriptenTool('emcc', [...CXXFLAGS, '-c', srcPath, '-o', objPath]);
     objectFiles.push(objPath);
 }
 
 // Create static archive
 console.log('Creating libimgui.a...');
 const archivePath = path.join(BUILD_DIR, 'libimgui.a');
-shell.exec(`emar rcs "${archivePath}" ${objectFiles.map((f) => `"${f}"`).join(' ')}`);
+runEmscriptenTool('emar', ['rcs', archivePath, ...objectFiles]);
 
 // --------------- deploy to sysroot ---------------
 

--- a/tools/emception/scripts/tests/ci-release-policy.test.mjs
+++ b/tools/emception/scripts/tests/ci-release-policy.test.mjs
@@ -29,6 +29,13 @@ test('Emception CI is Linux-only, lockfile-driven, receipt-aware, and Changesets
     true,
     'package clean/build must finish before the canonical CDN is staged',
   );
+  assert.match(workflow, /pnpm --filter @game-guild\/client run build/);
+  assert.equal(
+    workflow.indexOf('- name: Build generated API client')
+      < workflow.indexOf('- name: Run instructor and learner coding assessment cycle'),
+    true,
+    'the generated API client must exist before the coding-cycle runner imports it',
+  );
 
   const ignore = await readFile(path.join(repoRoot, '.gitignore'), 'utf8');
   const rootPackage = JSON.parse(await readFile(path.join(repoRoot, 'package.json'), 'utf8'));


### PR DESCRIPTION
## Summary
- build `@game-guild/client` before the Emception browser coding cycle
- enforce workflow ordering with a release-policy regression test
- replace insecure E2E randomness with `randomUUID`
- invoke ImGui compiler/archive tools without shell-built commands
- keep user-provided collaborator roles out of audit logs
- accept canonical JWT `sub` identities in course content authorization
- submit the current coding delta without an unnecessary third browser-toolchain compile

## Root causes
The Emception gate originally reached the browser assessment cycle after completing the toolchain build, but `apps/web/scripts/coding-cycle-browser-e2e.mjs` imports `@game-guild/client` whose export resolves to `dist/index.js`. The workflow had not built that package, causing `ERR_MODULE_NOT_FOUND`.

After that was fixed, the real browser cycle exposed two further runtime issues:
1. Learner authorization read only `ClaimTypes.NameIdentifier`, while production JWTs identify the user with `sub`.
2. Submit reran all public tests and recompiled the browser toolchain after the student had already run them, keeping the form in Submitting long enough to break the end-to-end workflow.

The release PR also exposed five CodeQL alerts in changed code, including one high-severity insecure-randomness finding.

Failed Emception evidence: https://github.com/gameguild-gg/gameguild/actions/runs/33330953977
Deep-cycle evidence before the final runtime fixes: https://github.com/gameguild-gg/gameguild/actions/runs/33337474540

## Validation
- `pnpm --filter @game-guild/client run build`
- `pnpm --dir tools/emception test:scripts` (55 passed)
- `pnpm run ci:repository-policy` (58 passed)
- `pnpm --dir tools/emception typecheck`
- `pnpm --dir apps/web exec eslint scripts/coding-cycle-browser-e2e.mjs`
- `node --check apps/web/scripts/coding-cycle-browser-e2e.mjs`
- Courses unit tests (380 passed)
- Coding activity component tests (7 passed)
- Targeted web ESLint
- Projects module Release build (0 warnings, 0 errors)
- Projects tests (237 passed)
- Full disposable-stack browser coding cycle: OVERALL GREEN, 38 assertions, submission + SpeedGrader + private tests + persisted score 100
- `git diff --check`