### PR TITLE
fix(testing-lab): restore production reviewer workflow

### DIFF
--- a/.changeset/isolate-emception-native-builds.md
+++ b/.changeset/isolate-emception-native-builds.md
@@ -1,0 +1,5 @@
+---
+"@gameguild/emception-browser": patch
+---
+
+Isolate and clean browser-native scratch outputs so sequential assessment runs cannot reuse stale object or WASM bytes.

--- a/apps/api/Source/Modules/GameGuild.Identity.Authentication/Services/JwtTokenService.cs
+++ b/apps/api/Source/Modules/GameGuild.Identity.Authentication/Services/JwtTokenService.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using GameGuild.Configuration.ApplicationLayer;
+using GameGuild.Identity.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -115,7 +116,9 @@ public sealed class JwtTokenService(
             };
 
             // Add roles
-            foreach (var role in roles) { claims.Add(new Claim(ClaimTypes.Role, role)); }
+            // The API disables inbound claim mapping and configures "role" as
+            // RoleClaimType, so access tokens must emit the canonical short claim.
+            foreach (var role in roles) { claims.Add(new Claim(ClaimNames.Role, role)); }
 
             // Add tenant claim if multi-tenant
             if (tenantId.HasValue) { claims.Add(new Claim("tenant_id", tenantId.Value.ToString())); }
@@ -281,7 +284,12 @@ public sealed class JwtTokenService(
 
             var userId = jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub)?.Value;
             var email = jwtToken.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Email)?.Value;
-            var roles = jwtToken.Claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value).ToArray();
+            // Read both the canonical API claim and the legacy URI claim so
+            // tokens issued immediately before this rollout remain readable.
+            var roles = jwtToken.Claims
+                .Where(c => c.Type == ClaimNames.Role || c.Type == ClaimTypes.Role || c.Type == "roles")
+                .Select(c => c.Value)
+                .ToArray();
             var tenantIdClaim = jwtToken.Claims.FirstOrDefault(c => c.Type == "tenant_id")?.Value;
 
             Guid? tenantId = null;

--- a/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/PermissionRuleEvaluators.cs
+++ b/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/PermissionRuleEvaluators.cs
@@ -49,6 +49,14 @@ public sealed class RequireAllPermissionsRuleEvaluator : IRuleEvaluator
             return RuleEvaluationResult.Fail("Could not determine user ID from claims");
         }
 
+        // System administrators have platform-wide permission authority. Keep the
+        // remaining policy rules (for example MFA and tenant matching) intact,
+        // while avoiding a tenant permission lookup that cannot represent this role.
+        if (Utilities.ClaimsExtractor.GetRoles(user).Contains(Policies.SystemAdmin))
+        {
+            return RuleEvaluationResult.Success();
+        }
+
         // Extract tenant ID from context (now Guid?) or claims
         Guid tenantId;
         if (_tenantContext.HasTenant && _tenantContext.TenantId.HasValue && _tenantContext.TenantId.Value != Guid.Empty)
@@ -122,6 +130,14 @@ public sealed class RequireAnyPermissionRuleEvaluator : IRuleEvaluator
         if (!userId.HasValue)
         {
             return RuleEvaluationResult.Fail("Could not determine user ID from claims");
+        }
+
+        // System administrators have platform-wide permission authority. Keep the
+        // remaining policy rules (for example MFA and tenant matching) intact,
+        // while avoiding a tenant permission lookup that cannot represent this role.
+        if (Utilities.ClaimsExtractor.GetRoles(user).Contains(Policies.SystemAdmin))
+        {
+            return RuleEvaluationResult.Success();
         }
 
         // Extract tenant ID from context (now Guid?) or claims

--- a/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/SelfOrPermissionRuleEvaluator.cs
+++ b/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/SelfOrPermissionRuleEvaluator.cs
@@ -50,6 +50,15 @@ public sealed class SelfOrPermissionRuleEvaluator : IRuleEvaluator
             return RuleEvaluationResult.Fail("Could not determine current user ID");
         }
 
+        // Platform administrators are the canonical "manage any user" actors. Their
+        // authority is role-based rather than stored as a tenant permission, so a
+        // tenant permission lookup would incorrectly reject them before the
+        // controller can apply its resource-level scope.
+        if (Utilities.ClaimsExtractor.GetRoles(user).Contains(Policies.SystemAdmin))
+        {
+            return RuleEvaluationResult.Success();
+        }
+
         // Extract tenant ID from context (now Guid?) or claims
         Guid tenantId;
         if (_tenantContext.HasTenant && _tenantContext.TenantId.HasValue && _tenantContext.TenantId.Value != Guid.Empty)

--- a/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/TenantMatchRuleEvaluator.cs
+++ b/apps/api/Source/Modules/GameGuild.Identity.Authorization/Rules/Evaluators/TenantMatchRuleEvaluator.cs
@@ -52,6 +52,14 @@ public sealed class TenantMatchRuleEvaluator : IRuleEvaluator
             return Task.FromResult(RuleEvaluationResult.Fail("No tenant context available"));
         }
 
+        // System administrators are explicitly platform-wide, but tenant-scoped
+        // requests must still resolve a concrete target tenant above. Once scoped,
+        // they may administer a tenant other than the one carried by their token.
+        if (Utilities.ClaimsExtractor.GetRoles(user).Contains(Policies.SystemAdmin))
+        {
+            return Task.FromResult(RuleEvaluationResult.Success());
+        }
+
         // Compare tenants - convert Guid to string for comparison with claim
         var requestTenantIdStr = requestTenantId.Value.ToString();
         if (!string.Equals(userTenantClaim, requestTenantIdStr, StringComparison.OrdinalIgnoreCase))

--- a/apps/api/Source/Modules/GameGuild.Identity.Authorization/Services/PolicyDefinitionSeeder.cs
+++ b/apps/api/Source/Modules/GameGuild.Identity.Authorization/Services/PolicyDefinitionSeeder.cs
@@ -8,7 +8,7 @@ namespace GameGuild.Identity.Authorization;
 /// </summary>
 public sealed class PolicyDefinitionSeeder
 {
-    public const long CurrentPolicyVersion = 3;
+    public const long CurrentPolicyVersion = 4;
 
     private readonly IPolicyDefinitionRepository _repository;
     private readonly ILogger<PolicyDefinitionSeeder> _logger;
@@ -888,6 +888,9 @@ public sealed class PolicyDefinitionSeeder
                 {
                     "Type": "TenantMatch",
                     "Description": "Ensure user belongs to the request tenant",
+                    "Params": {
+                        "allowNoTenant": true
+                    },
                     "Enabled": true
                 },
                 {

--- a/apps/api/tests/GameGuild.Identity.Authentication.UnitTests/Services/JwtTokenServiceTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authentication.UnitTests/Services/JwtTokenServiceTests.cs
@@ -78,6 +78,23 @@ public class JwtTokenServiceTests
     }
 
     [Fact]
+    public async Task GenerateAccessTokenAsync_RolesUseApiRoleClaimContract()
+    {
+        var token = await _service.GenerateAccessTokenAsync(
+            Guid.NewGuid(),
+            "admin@example.com",
+            ["SystemAdmin"],
+            Guid.NewGuid(),
+            1,
+            CancellationToken.None);
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        var role = jwt.Claims.Single(claim => claim.Value == "SystemAdmin");
+
+        role.Type.Should().Be("role");
+    }
+
+    [Fact]
     public async Task GenerateAccessTokenAsync_WithAuthenticationTime_ShouldPreserveAuthenticationTime()
     {
         var authenticatedAt = DateTimeOffset.UtcNow.AddMinutes(-12);

--- a/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/RequireAllPermissionsRuleEvaluatorTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/RequireAllPermissionsRuleEvaluatorTests.cs
@@ -112,6 +112,29 @@ public class RequireAllPermissionsRuleEvaluatorTests
     }
 
     [Fact]
+    public async Task EvaluateAsync_SystemAdministrator_ReturnsSuccessWithoutPermissionLookup()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new Claim(ClaimTypes.Role, Policies.SystemAdmin)
+        ], "TestAuth"));
+        var context = new AuthorizationHandlerContext([], user, null);
+        var parameters = RuleParameters.FromJson("{\"permissions\": [\"users:admin\"]}");
+
+        var result = await _evaluator.EvaluateAsync(context, parameters);
+
+        result.IsSuccess.Should().BeTrue();
+        _mockPermissionService.Verify(
+            x => x.HasAllPermissionsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task EvaluateAsync_HasAllPermissions_ReturnsSuccess()
     {
         // Arrange

--- a/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/RequireAnyPermissionRuleEvaluatorTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/RequireAnyPermissionRuleEvaluatorTests.cs
@@ -112,6 +112,29 @@ public class RequireAnyPermissionRuleEvaluatorTests
     }
 
     [Fact]
+    public async Task EvaluateAsync_SystemAdministrator_ReturnsSuccessWithoutPermissionLookup()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new Claim(ClaimTypes.Role, Policies.SystemAdmin)
+        ], "TestAuth"));
+        var context = new AuthorizationHandlerContext([], user, null);
+        var parameters = RuleParameters.FromJson("{\"permissions\": [\"users:admin\"]}");
+
+        var result = await _evaluator.EvaluateAsync(context, parameters);
+
+        result.IsSuccess.Should().BeTrue();
+        _mockPermissionService.Verify(
+            x => x.HasAnyPermissionAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<IEnumerable<string>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task EvaluateAsync_HasAnyPermission_ReturnsSuccess()
     {
         // Arrange

--- a/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/SelfOrPermissionRuleEvaluatorTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/SelfOrPermissionRuleEvaluatorTests.cs
@@ -72,6 +72,46 @@ public class SelfOrPermissionRuleEvaluatorTests
     }
 
     [Fact]
+    public async Task EvaluateAsync_SystemAdministratorTargetingAnotherUser_ReturnsSuccess()
+    {
+        var userId = Guid.NewGuid();
+        var tenantId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        var user = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim("sub", userId.ToString()),
+            new Claim("tid", tenantId.ToString()),
+            new Claim(ClaimTypes.Role, "SystemAdmin")
+        ], "test"));
+
+        _tenantContextMock.Setup(x => x.TenantId).Returns(tenantId);
+        _tenantContextMock.Setup(x => x.HasTenant).Returns(true);
+
+        var context = new AuthorizationHandlerContext(
+            [],
+            user,
+            new TestUserResource { UserId = targetUserId });
+        var parameters = RuleParameters.FromJson("{\"anyPermission\":\"users:manage\"}");
+
+        var result = await _evaluator.EvaluateAsync(context, parameters);
+
+        result.IsSuccess.Should().BeTrue();
+        _tenantMembershipCheckerMock.Verify(
+            x => x.IsUserMemberOfTenantAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _permissionServiceMock.Verify(
+            x => x.HasPermissionAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task EvaluateAsync_IsSelf_ReturnsSuccess()
     {
         var userId = Guid.NewGuid();

--- a/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/TenantMatchRuleEvaluatorTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/RuleEvaluators/TenantMatchRuleEvaluatorTests.cs
@@ -118,6 +118,27 @@ public class TenantMatchRuleEvaluatorTests
     }
 
     [Fact]
+    public async Task EvaluateAsync_SystemAdministratorCrossTenant_ReturnsSuccess()
+    {
+        var userTenantId = Guid.NewGuid();
+        var requestTenantId = Guid.NewGuid();
+        var claims = new List<Claim>
+        {
+            new(ClaimNames.TenantId, userTenantId.ToString()),
+            new(ClaimTypes.Role, Policies.SystemAdmin)
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        var context = new AuthorizationHandlerContext([], user, null);
+        var parameters = RuleParameters.FromJson("{}");
+
+        _mockTenantContext.Setup(x => x.TenantId).Returns(requestTenantId);
+
+        var result = await _evaluator.EvaluateAsync(context, parameters);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task EvaluateAsync_TenantMatch_ReturnsSuccess()
     {
         // Arrange

--- a/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/Services/PolicyDefinitionSeederTests.cs
+++ b/apps/api/tests/GameGuild.Identity.Authorization.UnitTests/Services/PolicyDefinitionSeederTests.cs
@@ -42,6 +42,8 @@ public class PolicyDefinitionSeederTests
             .RulesJson.Should().Contain("\"allowCreator\": true");
         added.Single(policy => policy.PolicyName == Policies.CourseContentManage)
             .RulesJson.Should().Contain("\"allowCreator\": false");
+        added.Single(policy => policy.PolicyName == Policies.UsersReadSelf)
+            .RulesJson.Should().Contain("\"allowNoTenant\": true");
         repo.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 

--- a/apps/web/eslint-suppressions.json
+++ b/apps/web/eslint-suppressions.json
@@ -1550,11 +1550,6 @@
       "count": 2
     }
   },
-  "src/components/testing-lab/testing-lab-session-registration.tsx": {
-    "@next/next/no-html-link-for-pages": {
-      "count": 46
-    }
-  },
   "src/components/ui/carousel.tsx": {
     "react-hooks/set-state-in-effect": {
       "count": 1

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -44,6 +44,7 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".next-*/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/apps/web/scripts/testing-lab-browser-e2e.mjs
+++ b/apps/web/scripts/testing-lab-browser-e2e.mjs
@@ -45,6 +45,21 @@ function unique() {
   return `${Date.now()}-${randomUUID().slice(0, 8)}`;
 }
 
+function accessTokenRoles(accessToken) {
+  const payload = accessToken.split(".")[1];
+  if (!payload) return [];
+
+  const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  const roleClaims = [
+    claims.role,
+    claims.roles,
+    claims["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"],
+  ];
+  return roleClaims
+    .flatMap((claim) => (Array.isArray(claim) ? claim : [claim]))
+    .filter((claim) => typeof claim === "string");
+}
+
 async function apiRequest(pathname, init = {}, accessToken, tenantId) {
   const response = await fetch(`${apiBaseUrl}${pathname}`, {
     ...init,
@@ -103,6 +118,12 @@ async function bootstrap() {
   if (!auth.accessToken || !auth.tenantId) {
     throw new Error(
       "The system administrator session did not expose accessToken and tenantId.",
+    );
+  }
+  const adminRoles = accessTokenRoles(auth.accessToken);
+  if (!adminRoles.some((role) => role.toLowerCase() === "systemadmin")) {
+    throw new Error(
+      `The seeded administrator token is missing SystemAdmin. Issued roles: ${adminRoles.join(", ") || "none"}.`,
     );
   }
 
@@ -405,8 +426,11 @@ async function visit(page, pathname, label) {
   }
   await assertNoErrorSurface(page, label);
   await page.waitForFunction(() => document.readyState !== "loading");
+  // RSC navigation can briefly replace the rendered route while the client
+  // applies its final payload. Run semantic checks only after that boundary,
+  // otherwise a valid heading can disappear between waitFor and evaluation.
+  await waitForClientHydration(page);
   await page.locator("h1").first().waitFor({ state: "visible" });
-  await page.waitForTimeout(350);
   quality.accessibilityFailures.push(
     ...(await collectAccessibilityFailures(page, label)),
   );

--- a/apps/web/src/app/[locale]/(dashboards)/workspace/economy/orders/[orderId]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboards)/workspace/economy/orders/[orderId]/page.tsx
@@ -1,6 +1,5 @@
 import { EconomyPageHeader, EconomyWorkspace, formatEconomyDate } from '@/components/economy/economy-ui';
 import { getMyMarketplaceOrder } from '@/lib/marketplace/queries';
-import { Badge } from '@game-guild/ui/components/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@game-guild/ui/components/card';
 import { getTranslations } from 'next-intl/server';
 import { notFound } from 'next/navigation';

--- a/apps/web/src/components/economy/economy-adaptive-refresh.test.tsx
+++ b/apps/web/src/components/economy/economy-adaptive-refresh.test.tsx
@@ -55,6 +55,17 @@ describe('EconomyAdaptiveRefresh', () => {
     expect(screen.getByText('active')).toBeInTheDocument();
   });
 
+  it('resets dirty state after navigation', () => {
+    const { rerender } = render(<EconomyAdaptiveRefresh><input aria-label="field" /></EconomyAdaptiveRefresh>);
+    fireEvent.input(screen.getByLabelText('field'), { target: { value: 'edited' } });
+    expect(screen.getByText('paused')).toBeInTheDocument();
+
+    mocks.pathname = '/workspace/economy/orders';
+    rerender(<EconomyAdaptiveRefresh><input aria-label="field" /></EconomyAdaptiveRefresh>);
+
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
   it('pauses in a hidden tab and backs off while offline', () => {
     const { rerender } = render(<EconomyAdaptiveRefresh><p>content</p></EconomyAdaptiveRefresh>);
     Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });

--- a/apps/web/src/components/economy/economy-adaptive-refresh.tsx
+++ b/apps/web/src/components/economy/economy-adaptive-refresh.tsx
@@ -12,17 +12,17 @@ export function getEconomyPollingInterval(pathname: string) {
   return fastSurfaces.test(pathname) ? 15_000 : 30_000;
 }
 export function EconomyAdaptiveRefresh({ children }: { children: ReactNode }) {
-  const t = useTranslations('economy.refresh');
   const pathname = usePathname() ?? '';
+  return <EconomyAdaptiveRefreshForPath key={pathname} pathname={pathname}>{children}</EconomyAdaptiveRefreshForPath>;
+}
+
+function EconomyAdaptiveRefreshForPath({ children, pathname }: { children: ReactNode; pathname: string }) {
+  const t = useTranslations('economy.refresh');
   const router = useRouter();
   const [dirty, setDirty] = useState(false);
   const [hidden, setHidden] = useState(false);
   const [offline, setOffline] = useState(false);
   const failures = useRef(0);
-
-  useEffect(() => {
-    setDirty(false);
-  }, [pathname]);
 
   useEffect(() => {
     const visibility = () => setHidden(document.visibilityState === 'hidden');

--- a/apps/web/src/components/testing-lab/testing-lab-session-registration.tsx
+++ b/apps/web/src/components/testing-lab/testing-lab-session-registration.tsx
@@ -10,6 +10,7 @@ import {
 import { Alert, AlertDescription } from '@game-guild/ui/components/alert';
 import { Button } from '@game-guild/ui/components/button';
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
+import Link from 'next/link';
 import { useState, useTransition } from 'react';
 
 type RegistrationState = 'idle' | 'registered' | 'waitlisted';
@@ -51,7 +52,7 @@ export function TestingLabSessionRegistration({
   if (!isAuthenticated) {
     return (
       <Button asChild className="w-full">
-        <a href="/sign-in?callbackUrl=%2Ftesting-lab">Sign in to join this session</a>
+        <Link href="/sign-in?callbackUrl=%2Ftesting-lab">Sign in to join this session</Link>
       </Button>
     );
   }

--- a/apps/web/src/lib/economy/console-actions.test.ts
+++ b/apps/web/src/lib/economy/console-actions.test.ts
@@ -2,10 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const api = vi.fn(async () => ({ ok: true, data: { id: 'result' } }));
-  const module = () => new Proxy({}, { get: (_target, property) => (...args: unknown[]) => api(String(property), args) });
+  const moduleProxy = () => new Proxy({}, { get: (_target, property) => (...args: unknown[]) => api(String(property), args) });
   return {
     api,
-    modules: { admin: module(), authStepUp: module(), compliance: module(), holds: module(), legacy: module(), risk: module(), treasury: module() },
+    modules: {
+      admin: moduleProxy(),
+      authStepUp: moduleProxy(),
+      compliance: moduleProxy(),
+      holds: moduleProxy(),
+      legacy: moduleProxy(),
+      risk: moduleProxy(),
+      treasury: moduleProxy(),
+    },
     requireSurface: vi.fn(async () => ({})),
     revalidatePath: vi.fn(),
   };

--- a/apps/web/src/lib/testing-lab/actions.test.ts
+++ b/apps/web/src/lib/testing-lab/actions.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
-  getToken: vi.fn(),
-  auth: vi.fn(),
+  getRequestAuthContext: vi.fn(),
+  createServerClient: vi.fn(() => ({})),
   revalidatePath: vi.fn(),
   postTestingSubmitSimple: vi.fn(),
   deleteTestingRequests: vi.fn(),
@@ -20,8 +20,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/auth', () => ({
-  getToken: mocks.getToken,
-  auth: mocks.auth,
+  getRequestAuthContext: mocks.getRequestAuthContext,
 }));
 
 vi.mock('next/cache', () => ({
@@ -29,7 +28,7 @@ vi.mock('next/cache', () => ({
 }));
 
 vi.mock('@game-guild/client', () => ({
-  createServerClient: vi.fn(() => ({})),
+  createServerClient: mocks.createServerClient,
   GeneratedApi: {
     TestingLabTestingRequestsModule: vi.fn(function TestingLabTestingRequestsModule() {
       return {
@@ -93,8 +92,22 @@ function form(values: Record<string, string>) {
 describe('Testing Lab server actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getToken.mockResolvedValue('token');
-    mocks.auth.mockResolvedValue({ user: { id: 'manager-1' }, tenantId: 'tenant-1' });
+    mocks.getRequestAuthContext.mockResolvedValue({
+      token: 'token',
+      tenantId: 'tenant-1',
+      session: { user: { id: 'manager-1' }, tenantId: 'tenant-1' },
+    });
+  });
+
+  it('uses one request authentication context for both token and tenant', async () => {
+    mocks.postApiTestingLabPermissionsRoleTemplates.mockResolvedValue({ ok: true, data: { id: 'role-1' } });
+
+    await createTestingLabRole(form({ name: 'Facilitator' }));
+
+    const clientOptions = mocks.createServerClient.mock.calls[0]?.[0];
+    await expect(clientOptions.auth.getAccessToken()).resolves.toBe('token');
+    await expect(clientOptions.tenant.getTenantId()).resolves.toBe('tenant-1');
+    expect(mocks.getRequestAuthContext).toHaveBeenCalledTimes(1);
   });
 
   it('submits a build through the generated requests client', async () => {

--- a/apps/web/src/lib/testing-lab/actions.ts
+++ b/apps/web/src/lib/testing-lab/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { auth, getToken } from '@/auth';
+import { getRequestAuthContext } from '@/auth';
 import {
   createServerClient,
   GeneratedApi,
@@ -25,11 +25,11 @@ type TestingLabActionData<T> = [T] extends [void] ? null : T | null;
 
 export type TestingLabActionResult<T = null> = { success: true; data: TestingLabActionData<T>; message: string } | { success: false; error: string };
 
-function createModules() {
+function createModules(requestAuth = getRequestAuthContext()) {
   const client = createServerClient({
     baseUrl: process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080',
-    auth: { getAccessToken: () => getToken() },
-    tenant: { getTenantId: async () => (await auth().catch(() => null))?.tenantId ?? null },
+    auth: { getAccessToken: async () => (await requestAuth).token },
+    tenant: { getTenantId: async () => (await requestAuth).tenantId },
   });
 
   return {
@@ -202,12 +202,13 @@ export async function createTestingSession(formData: FormData): Promise<TestingL
   );
   if (invalid) return invalid;
 
-  const session = await auth().catch(() => null);
+  const requestAuth = getRequestAuthContext();
+  const { session } = await requestAuth;
   const managerUserId = text(formData, 'managerUserId') || session?.user?.id?.trim();
   if (!managerUserId) return { success: false, error: 'A session manager is required.' };
 
   return complete(
-    createModules().sessions.postTestingSessions({
+    createModules(requestAuth).sessions.postTestingSessions({
       testingRequestId: text(formData, 'testingRequestId'),
       locationId: text(formData, 'locationId'),
       managerUserId,

--- a/tools/emception/packages/browser/src/createEmception.ts
+++ b/tools/emception/packages/browser/src/createEmception.ts
@@ -154,6 +154,7 @@ function wrap(client: WorkerClient): BrowserEmceptionAPI {
     // Local workspace state.
     let currentBuild: WorkspaceBuildConfig = { toolchain: ToolchainPreset.CPP };
     let currentWorkspaceName = 'default';
+    let nativeBuildSequence = 0;
     const mountPath = () => `/home/user/${currentWorkspaceName}`;
 
     /** Translate a core RunOptions into the browser WorkerClient RunOptions. */
@@ -254,42 +255,60 @@ function wrap(client: WorkerClient): BrowserEmceptionAPI {
                     throw new Error(`compileAndRun: toolchain '${toolchain}' does not support native source builds`);
                 }
 
-                const objectPaths = sourcePaths.map((_, index) => `/tmp/emception-build-${index}.o`);
-                const wasmPath = nativeBuild?.output ?? '/tmp/emception-build.wasm';
+                // Every native build gets private scratch files. Reusing a
+                // shorter output path can leave stale bytes in Emscripten's
+                // process-local VFS mapping and corrupt a later WASM module.
+                const scratchPrefix = `/tmp/emception-build-${++nativeBuildSequence}`;
+                const objectPaths = sourcePaths.map((_, index) => `${scratchPrefix}-${index}.o`);
+                const wasmPath = nativeBuild?.output ?? `${scratchPrefix}.wasm`;
+                const scratchPaths = nativeBuild?.output
+                    ? objectPaths
+                    : [...objectPaths, wasmPath];
                 const runOptions = {
                     ...(opts?.cwd ? { cwd: opts.cwd } : {}),
                     ...(opts?.stdout ? { stdout: opts.stdout } : {}),
                     ...(opts?.stderr ? { stderr: opts.stderr } : {}),
                 };
 
-                for (let index = 0; index < sourcePaths.length; index++) {
-                    const compile = await run(
-                        preset.compileTool,
-                        preset.compileArgv({
-                            sourcePath: sourcePaths[index]!,
-                            objectPath: objectPaths[index]!,
-                        }),
-                        runOptions,
-                    );
-                    if (compile.exitCode !== 0) return compile;
-                }
+                try {
+                    // An explicit artifact path is caller-owned and remains
+                    // after the run, but it must never be linked over stale
+                    // VFS contents from a previous invocation.
+                    if (nativeBuild?.output) {
+                        await Promise.allSettled([client.deleteFile(wasmPath)]);
+                    }
 
-                const linkArgs = preset.linkArgv({
-                    objectPath: objectPaths[0]!,
-                    wasmPath,
-                });
-                const firstObjectIndex = linkArgs.indexOf(objectPaths[0]!);
-                if (firstObjectIndex === -1) {
-                    throw new Error('compileAndRun: preset linker argv does not contain its object path');
-                }
-                linkArgs.splice(firstObjectIndex, 1, ...objectPaths);
-                const link = await run(preset.linkTool, linkArgs, runOptions);
-                if (link.exitCode !== 0) return link;
+                    for (let index = 0; index < sourcePaths.length; index++) {
+                        const compile = await run(
+                            preset.compileTool,
+                            preset.compileArgv({
+                                sourcePath: sourcePaths[index]!,
+                                objectPath: objectPaths[index]!,
+                            }),
+                            runOptions,
+                        );
+                        if (compile.exitCode !== 0) return compile;
+                    }
 
-                return run('wasi-run', ['wasi-run', wasmPath], {
-                    ...runOptions,
-                    ...(stdinStr === undefined ? {} : { stdin: stdinStr }),
-                });
+                    const linkArgs = preset.linkArgv({
+                        objectPath: objectPaths[0]!,
+                        wasmPath,
+                    });
+                    const firstObjectIndex = linkArgs.indexOf(objectPaths[0]!);
+                    if (firstObjectIndex === -1) {
+                        throw new Error('compileAndRun: preset linker argv does not contain its object path');
+                    }
+                    linkArgs.splice(firstObjectIndex, 1, ...objectPaths);
+                    const link = await run(preset.linkTool, linkArgs, runOptions);
+                    if (link.exitCode !== 0) return link;
+
+                    return await run('wasi-run', ['wasi-run', wasmPath], {
+                        ...runOptions,
+                        ...(stdinStr === undefined ? {} : { stdin: stdinStr }),
+                    });
+                } finally {
+                    await Promise.allSettled(scratchPaths.map((path) => client.deleteFile(path)));
+                }
             }
 
             // ponytail: CompileAndRunOptions has no timeoutMs field; the

--- a/tools/emception/packages/browser/tests/facade.test.mjs
+++ b/tools/emception/packages/browser/tests/facade.test.mjs
@@ -55,7 +55,54 @@ test('facade.runTests compiles persisted plan sources without replacing them wit
   );
   const link = runs.find(({ cmd }) => cmd === 'wasm-ld');
   assert.ok(link, 'links all compiled source objects');
-  assert.equal(link.argv.filter((value) => /^\/tmp\/emception-build-\d+\.o$/.test(value)).length, 2);
+  assert.equal(link.argv.filter((value) => /^\/tmp\/emception-build-\d+-\d+\.o$/.test(value)).length, 2);
+});
+
+test('facade isolates native scratch outputs between sequential test runs', async () => {
+  const runs = [];
+  const api = wrapWorkerClient(makeStubClient({
+    run: async (cmd, argv) => {
+      runs.push({ cmd, argv });
+      return { exitCode: 0, stdout: '5\n', stderr: '', durationMs: 1, timedOut: false };
+    },
+  }));
+
+  const plan = {
+    build: {
+      toolchain: ToolchainPreset.CPP,
+      sources: ['/user/main.cpp'],
+    },
+    cases: [{ kind: 'stdio', expectedStdout: '5\n' }],
+  };
+
+  await api.runTests(plan);
+  await api.runTests(plan);
+
+  const links = runs.filter(({ cmd }) => cmd === 'wasm-ld');
+  assert.equal(links.length, 2);
+  const outputs = links.map(({ argv }) => argv[argv.indexOf('-o') + 1]);
+  assert.notEqual(outputs[0], outputs[1], 'each invocation must use a fresh WASM output path');
+});
+
+test('facade removes an explicit native output before relinking it', async () => {
+  const deletedPaths = [];
+  const api = wrapWorkerClient(makeStubClient({
+    deleteFile: async (path) => { deletedPaths.push(path); },
+  }));
+
+  await api.compileAndRun(undefined, {
+    build: {
+      toolchain: ToolchainPreset.CPP,
+      sources: ['/user/main.cpp'],
+      output: '/user/program.wasm',
+    },
+  });
+
+  assert.equal(deletedPaths[0], '/user/program.wasm');
+  assert.ok(
+    deletedPaths.some((path) => /^\/tmp\/emception-build-\d+-0\.o$/.test(path)),
+    'private object files are cleaned after execution',
+  );
 });
 
 test('facade.runTests resolves a TestReport-shaped value', async () => {


### PR DESCRIPTION
Aligns JWT role claims and SystemAdmin policy evaluation; scopes Testing Lab server actions to one request authentication context; hardens the reviewer browser journey; restores the clean web lint/build gate; and isolates sequential Emception native builds. Verified with workspace lint (12/12), workspace typecheck (31/31), 3,508 relevant .NET tests, relevant Web tests, API Release publish, Next 16.3 production build (300/300 pages), and the complete Testing Lab browser E2E using API Release, Next production, and disposable PostgreSQL.