### PR TITLE
fix(web): normalize adaptive refresh pathname

### DIFF
--- a/apps/web/src/components/economy/economy-adaptive-refresh.tsx
+++ b/apps/web/src/components/economy/economy-adaptive-refresh.tsx
@@ -12,8 +12,9 @@ export function getEconomyPollingInterval(pathname: string) {
   return fastSurfaces.test(pathname) ? 15_000 : 30_000;
 }
 export function EconomyAdaptiveRefresh({ children }: { children: ReactNode }) {
-  const pathname = usePathname() ?? '';
-  return <EconomyAdaptiveRefreshForPath key={pathname} pathname={pathname}>{children}</EconomyAdaptiveRefreshForPath>;
+  const pathname = usePathname();
+  const safePathname = typeof pathname === 'string' ? pathname : '';
+  return <EconomyAdaptiveRefreshForPath key={safePathname} pathname={safePathname}>{children}</EconomyAdaptiveRefreshForPath>;
 }
 
 function EconomyAdaptiveRefreshForPath({ children, pathname }: { children: ReactNode; pathname: string }) {


### PR DESCRIPTION
Normalizes usePathname() before assigning it to the keyed adaptive refresh component, resolving the Codacy unsafe-assignment annotation without changing runtime behavior. Verified with focused ESLint and all 6 EconomyAdaptiveRefresh tests.