### PR TITLE
fix(ci): align production smoke and client metadata

### DIFF
--- a/apps/web/scripts/public-browser-smoke.mjs
+++ b/apps/web/scripts/public-browser-smoke.mjs
@@ -135,7 +135,13 @@ async function main() {
   });
   page.on('response', (response) => {
     const status = response.status();
-    if (status === 404 || status >= 500) {
+    const request = response.request();
+    const isRefusedCloudflarePrefetch =
+      status === 503 &&
+      request.headers()['sec-purpose'] === 'prefetch' &&
+      response.headers()['cf-speculation-refused']?.startsWith('prefetch refused:');
+
+    if ((status === 404 || status >= 500) && !isRefusedCloudflarePrefetch) {
       requestErrors.push(`${response.request().method()} ${response.url()}: HTTP ${response.status()}`);
     }
   });

--- a/packages/infrastructure/client/src/generated/.metadata.json
+++ b/packages/infrastructure/client/src/generated/.metadata.json
@@ -1,7 +1,7 @@
 {
-  "hash": "efc53dbce6c8ea45c8ac2851f4962f0197e39469e4b714a5c90d4f79f4702d8c",
+  "hash": "d22b7492afd13c80e3098d1f45ae440b51a2fe85a6a6c861da62176822863515",
   "apiVersion": "4.3.0",
   "source": "gameguild-openapi",
-  "generatedAt": "2026-08-31T02:48:19.313Z",
+  "generatedAt": "2026-08-31T17:07:12.193Z",
   "generatedBy": "MatheusMartins"
 }


### PR DESCRIPTION
Fixes both issues found during the live production verification: (1) the public browser smoke now ignores only Cloudflare Speed Brain's explicit speculative refusal (503 + sec-purpose=prefetch + Cf-Speculation-Refused), while preserving failures for real 404/5xx responses; (2) generated client metadata is synchronized to the exact normalized OpenAPI artifact from failed main run 33414340759. Verified with production headers, script syntax/lint, the complete official public browser smoke against https://gameguild.gg/en-US, and a green pnpm generate:diff (no generated TypeScript changes).