### PR TITLE
fix(ci): close production release verification gaps

### DIFF
--- a/apps/web/scripts/public-browser-smoke.mjs
+++ b/apps/web/scripts/public-browser-smoke.mjs
@@ -135,7 +135,13 @@ async function main() {
   });
   page.on('response', (response) => {
     const status = response.status();
-    if (status === 404 || status >= 500) {
+    const request = response.request();
+    const isRefusedCloudflarePrefetch =
+      status === 503 &&
+      request.headers()['sec-purpose'] === 'prefetch' &&
+      response.headers()['cf-speculation-refused']?.startsWith('prefetch refused:');
+
+    if ((status === 404 || status >= 500) && !isRefusedCloudflarePrefetch) {
       requestErrors.push(`${response.request().method()} ${response.url()}: HTTP ${response.status()}`);
     }
   });

--- a/packages/infrastructure/client/src/generated/.metadata.json
+++ b/packages/infrastructure/client/src/generated/.metadata.json
@@ -1,7 +1,7 @@
 {
-  "hash": "efc53dbce6c8ea45c8ac2851f4962f0197e39469e4b714a5c90d4f79f4702d8c",
+  "hash": "d22b7492afd13c80e3098d1f45ae440b51a2fe85a6a6c861da62176822863515",
   "apiVersion": "4.3.0",
   "source": "gameguild-openapi",
-  "generatedAt": "2026-08-31T02:48:19.313Z",
+  "generatedAt": "2026-08-31T17:07:12.193Z",
   "generatedBy": "MatheusMartins"
 }


### PR DESCRIPTION
## Summary
- accept only Cloudflare-refused speculative prefetches in the public browser smoke
- synchronize generated client metadata with the normalized OpenAPI artifact used by CI

## Verification
- public production browser smoke passes against https://gameguild.gg/en-US
- generated client diff gate passes locally against the exact CI OpenAPI artifact
- API readiness/liveness and Testing Lab public routes are healthy in production

No runtime business logic or database migration is included in this promotion.